### PR TITLE
Filter noise & inline tests in /convert/tree

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,3 +98,55 @@ jobs:
         run: |
           python -m pip install pytest
           python -m pytest -q
+  probes:
+    needs: test
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+          cache: 'pip'
+
+      - name: Install deps & start orchestrator (background)
+        run: |
+          python -m pip install -U pip
+          if [ -f requirements.txt ]; then python -m pip install -r requirements.txt; fi
+          uvicorn app.server:create_app --factory --host 127.0.0.1 --port 8121 --log-level warning &
+          echo $! > uvicorn.pid
+          # simple wait for boot
+          for i in $(seq 1 30); do
+            if curl -fsS http://127.0.0.1:8121/_health >/dev/null; then break; fi
+            sleep 1
+          done
+
+      - name: Probe endpoints
+        run: |
+          set -euo pipefail
+          curl -fsS http://127.0.0.1:8121/_health
+          curl -fsS http://127.0.0.1:8121/_meta/routes > routes.json
+          test $(python - <<'PY'
+          import json; print(len(json.load(open("routes.json"))["routes"]))
+          PY
+          ) -ge 1
+          curl -fsS http://127.0.0.1:8121/readyz > readyz.json
+          python - <<'PY'
+          import json, sys
+          j = json.load(open("readyz.json"))
+          assert j.get("ok") is True, "readyz.ok != true"
+          checks = j.get("checks", {})
+          enabled = set(checks.get("providers_enabled", []))
+          if not (("grok" in enabled) or checks.get("sdk_grok_xai") is True):
+              raise SystemExit("grok provider not enabled in readyz")
+          print("readyz OK; grok present")
+          PY
+
+      - name: Teardown
+        if: always()
+        run: |
+          if [ -f uvicorn.pid ]; then kill $(cat uvicorn.pid) || true; fi
+

--- a/Use this whenever you want to bring the server up cleanly.txt
+++ b/Use this whenever you want to bring the server up cleanly.txt
@@ -1,0 +1,16 @@
+Set-Location C:\c\ai-orchestrator
+
+# 1) Load .env into THIS tab
+Load-DotEnv   # (your helper is already defined)
+
+# Optional: explicitly disable Anthropic
+Remove-Item Env:ANTHROPIC_API_KEY -ErrorAction SilentlyContinue
+$env:ANTHROPIC_API_KEY = ""
+
+# 2) Kill any listener on the port
+$cons = Get-NetTCPConnection -LocalPort $env:PORT -State Listen -ErrorAction SilentlyContinue
+if ($cons) { ($cons | Select-Object -Expand OwningProcess -Unique) | % { Stop-Process -Id $_ -Force } }
+
+# 3) Start uvicorn in the foreground
+$py = "C:\c\ai-orchestrator\venv\Scripts\python.exe"
+& $py -m uvicorn app.server:create_app --factory --host $env:HOST --port $env:PORT --log-level info

--- a/api/routes.py
+++ b/api/routes.py
@@ -1,27 +1,59 @@
-# C:\c\ai-orchestrator\api\routes.py
+# api/routes.py
 from __future__ import annotations
 
-from pathlib import Path
-from fastapi import APIRouter, Body
-from typing import Any, Dict, List
-import os
 import json
+import os
+import re
 from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List
+
+from fastapi import APIRouter, Body
+from pydantic import BaseModel
+
+from app.ai.reviewer import review_file
 
 router = APIRouter()
 
-# Try to load a reviewer (rule-based or LLM-backed).
-# If unavailable, we simply skip reviews.
-try:
-    from app.ai.reviewer import review_file  # optional module you can add later
-except Exception:
-    review_file = None  # type: ignore
+
+class ConvertTreeReq(BaseModel):
+    root: str = "src"
+    dry_run: bool = True
+    batch_cap: int = 25  # how many files to review per call (safety)
 
 
-# --- providers ---
+# --- constants (module scope) ---
+CODE_EXTS = {".ts", ".tsx", ".js", ".jsx"}
+
+# file/dir noise filters
+IGNORE_NAMES = {"desktop.ini", ".ds_store", "thumbs.db"}
+IGNORE_SUFFIXES = (".bak", ".tmp", "~")
+IGNORE_DIR_PARTS = {"/__mocks__/", "/tests/"}  # hide these directories from listings/reviews
+
+# inline test name patterns (e.g., foo.test.tsx, bar.spec.js)
+TEST_NAME_RE = re.compile(r"\.(test|spec)\.[a-z0-9]+$", re.I)
+
+
+def _is_noise(p: Path) -> bool:
+    """Return True for files/dirs we want to hide from listings/reviews."""
+    name_l = p.name.lower()
+    if name_l in IGNORE_NAMES:
+        return True
+    if name_l.endswith(IGNORE_SUFFIXES):
+        return True
+    if TEST_NAME_RE.search(name_l):  # inline tests
+        return True
+    # path-based directory filters
+    ppos = p.as_posix().lower()
+    for part in IGNORE_DIR_PARTS:
+        if part in ppos:
+            return True
+    return False
+
+
 @router.get("/providers/list", tags=["providers"], name="providers_list")
 def providers_list() -> dict:
-    return {"providers": ["openai", "gemini", "anthropic", "grok"]}
+    return {"providers": ["openai", "gemini", "grok", "anthropic"]}
 
 
 @router.get("/providers/selftest", tags=["providers"], name="providers_selftest")
@@ -29,75 +61,74 @@ def providers_selftest() -> dict:
     return {"ok": True}
 
 
-# --- convert ---
 @router.post("/convert/file", tags=["convert"], name="convert_file")
 def convert_file() -> dict:
-    # stub: replace with real logic when ready
+    # Placeholder for single-file conversion
     return {"ok": True, "converted": 1, "skipped": 0}
 
 
 @router.post("/convert/tree", tags=["convert"], name="convert_tree")
-def convert_tree(
-    root: str = Body("src", embed=True),         # expects {"root": "..."}
-    dry_run: bool = Body(True, embed=True),      # expects {"dry_run": true}
-    batch_cap: int = Body(25, embed=True),       # optional: cap files to review
-) -> dict:
-    """
-    Walk `root`, list up to 50 paths to keep payload small.
-    If a reviewer is available, review up to `batch_cap` code files (.ts/.tsx/.js/.jsx).
-    Persist a JSON artifact under reports/ for post-processing (routing audit, docs mirror).
-    """
-    p = Path(root)
+def convert_tree(req: ConvertTreeReq = Body(...)) -> dict:
+    root = Path(req.root)
     converted: List[str] = []
     skipped: List[str] = []
     reviews: List[Dict[str, Any]] = []
 
-    if p.exists() and p.is_dir():
-        items = list(p.rglob("*"))
-        # match previous behavior: cap at 50 for response size predictability
-        for item in items[:50]:
-            (converted if item.is_file() else skipped).append(str(item).replace("\\", "/"))
+    if root.exists() and root.is_dir():
+        # Gather and filter once
+        all_items = list(root.rglob("*"))
+        items: List[Path] = []
+        for p in all_items:
+            if _is_noise(p):
+                continue
+            items.append(p)
 
-        # Optional reviews
-        if review_file is not None:
-            CODE_EXTS = {".ts", ".tsx", ".js", ".jsx"}
-            code_files = [i for i in items if i.is_file() and i.suffix.lower() in CODE_EXTS]
-            cap = max(0, int(batch_cap))
-            for fp in code_files[:cap]:
-                try:
-                    r = review_file(
-                        str(fp),
-                        repo_root=os.getenv("FRONTEND_ROOT", r"C:\CFH\frontend")
-                    )
-                    reviews.append({
-                        "file": str(fp).replace("\\", "/"),
-                        "routing": r.get("routing", {"suggested_moves": []}),
-                        "markdown": r.get("markdown", ""),
-                    })
-                except Exception as e:
-                    reviews.append({
-                        "file": str(fp).replace("\\", "/"),
+        # Response-friendly listing (cap 200)
+        for p in items[:200]:
+            (converted if p.is_file() else skipped).append(str(p).replace("\\", "/"))
+
+        # Review only code files (cap per request)
+        cap = max(0, int(req.batch_cap))
+        code_files = [p for p in items if p.is_file() and p.suffix.lower() in CODE_EXTS]
+        for p in code_files[:cap]:
+            try:
+                r = review_file(
+                    str(p),
+                    repo_root=os.getenv("FRONTEND_ROOT", r"C:\CFH\frontend"),
+                )
+                reviews.append(
+                    {
+                        "file": str(p).replace("\\", "/"),
+                        "routing": r["routing"],
+                        "markdown": r["markdown"],
+                    }
+                )
+            except Exception as e:
+                reviews.append(
+                    {
+                        "file": str(p).replace("\\", "/"),
                         "error": repr(e),
                         "routing": {"suggested_moves": []},
                         "markdown": "",
-                    })
+                    }
+                )
 
-    resp: Dict[str, Any] = {
+    resp = {
         "ok": True,
-        "root": str(p),
-        "dry_run": bool(dry_run),
+        "root": str(root),
+        "dry_run": req.dry_run,
         "converted": converted,
         "skipped": skipped,
         "reviews_count": len(reviews),
         "reviews": reviews,
     }
 
-    # Persist artifact for post-processing (routing audit, moves, docs mirror)
+    # Save artifact
+    reports_dir = Path(os.getenv("REPORTS_DIR", "reports"))
+    reports_dir.mkdir(parents=True, exist_ok=True)
+    stamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    out = reports_dir / f"convert_dryrun_{stamp}.json"
     try:
-        reports_dir = Path(os.getenv("REPORTS_DIR", "reports"))
-        reports_dir.mkdir(parents=True, exist_ok=True)
-        stamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-        out = reports_dir / f"convert_dryrun_{stamp}.json"
         out.write_text(json.dumps(resp, ensure_ascii=False, indent=2), encoding="utf-8")
         resp["artifact"] = str(out)
     except Exception as e:

--- a/api/routes.py
+++ b/api/routes.py
@@ -1,17 +1,33 @@
+# C:\c\ai-orchestrator\api\routes.py
 from __future__ import annotations
+
 from pathlib import Path
 from fastapi import APIRouter, Body
+from typing import Any, Dict, List
+import os
+import json
+from datetime import datetime
 
 router = APIRouter()
+
+# Try to load a reviewer (rule-based or LLM-backed).
+# If unavailable, we simply skip reviews.
+try:
+    from app.ai.reviewer import review_file  # optional module you can add later
+except Exception:
+    review_file = None  # type: ignore
+
 
 # --- providers ---
 @router.get("/providers/list", tags=["providers"], name="providers_list")
 def providers_list() -> dict:
     return {"providers": ["openai", "gemini", "anthropic", "grok"]}
 
+
 @router.get("/providers/selftest", tags=["providers"], name="providers_selftest")
 def providers_selftest() -> dict:
     return {"ok": True}
+
 
 # --- convert ---
 @router.post("/convert/file", tags=["convert"], name="convert_file")
@@ -19,22 +35,72 @@ def convert_file() -> dict:
     # stub: replace with real logic when ready
     return {"ok": True, "converted": 1, "skipped": 0}
 
+
 @router.post("/convert/tree", tags=["convert"], name="convert_tree")
 def convert_tree(
-    root: str = Body("src", embed=True),        # expects {"root": "..."}
-    dry_run: bool = Body(True, embed=True),     # expects {"dry_run": true}
+    root: str = Body("src", embed=True),         # expects {"root": "..."}
+    dry_run: bool = Body(True, embed=True),      # expects {"dry_run": true}
+    batch_cap: int = Body(25, embed=True),       # optional: cap files to review
 ) -> dict:
+    """
+    Walk `root`, list up to 50 paths to keep payload small.
+    If a reviewer is available, review up to `batch_cap` code files (.ts/.tsx/.js/.jsx).
+    Persist a JSON artifact under reports/ for post-processing (routing audit, docs mirror).
+    """
     p = Path(root)
-    converted: list[str] = []
-    skipped: list[str] = []
+    converted: List[str] = []
+    skipped: List[str] = []
+    reviews: List[Dict[str, Any]] = []
+
     if p.exists() and p.is_dir():
-        # cap output to keep responses small and predictable
-        for item in list(p.rglob("*"))[:50]:
+        items = list(p.rglob("*"))
+        # match previous behavior: cap at 50 for response size predictability
+        for item in items[:50]:
             (converted if item.is_file() else skipped).append(str(item).replace("\\", "/"))
-    return {
+
+        # Optional reviews
+        if review_file is not None:
+            CODE_EXTS = {".ts", ".tsx", ".js", ".jsx"}
+            code_files = [i for i in items if i.is_file() and i.suffix.lower() in CODE_EXTS]
+            cap = max(0, int(batch_cap))
+            for fp in code_files[:cap]:
+                try:
+                    r = review_file(
+                        str(fp),
+                        repo_root=os.getenv("FRONTEND_ROOT", r"C:\CFH\frontend")
+                    )
+                    reviews.append({
+                        "file": str(fp).replace("\\", "/"),
+                        "routing": r.get("routing", {"suggested_moves": []}),
+                        "markdown": r.get("markdown", ""),
+                    })
+                except Exception as e:
+                    reviews.append({
+                        "file": str(fp).replace("\\", "/"),
+                        "error": repr(e),
+                        "routing": {"suggested_moves": []},
+                        "markdown": "",
+                    })
+
+    resp: Dict[str, Any] = {
         "ok": True,
         "root": str(p),
         "dry_run": bool(dry_run),
         "converted": converted,
         "skipped": skipped,
+        "reviews_count": len(reviews),
+        "reviews": reviews,
     }
+
+    # Persist artifact for post-processing (routing audit, moves, docs mirror)
+    try:
+        reports_dir = Path(os.getenv("REPORTS_DIR", "reports"))
+        reports_dir.mkdir(parents=True, exist_ok=True)
+        stamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        out = reports_dir / f"convert_dryrun_{stamp}.json"
+        out.write_text(json.dumps(resp, ensure_ascii=False, indent=2), encoding="utf-8")
+        resp["artifact"] = str(out)
+    except Exception as e:
+        resp["artifact_error"] = repr(e)
+
+    return resp

--- a/app/ai/__init__.py
+++ b/app/ai/__init__.py
@@ -1,0 +1,2 @@
+# C:\c\ai-orchestrator\app\ai\__init__.py
+# (intentionally empty)

--- a/app/ai/reviewer.py
+++ b/app/ai/reviewer.py
@@ -1,0 +1,124 @@
+# C:\c\ai-orchestrator\app\ai\reviewer.py
+from __future__ import annotations
+
+import os
+import re
+from pathlib import Path
+from typing import Any, Dict, List, Tuple
+
+
+# Simple keyword → subfolder hints; add more as you learn the repo.
+BUCKET_RULES: List[Tuple[str, str, float]] = [
+    (r"\bbuyer\b|\bcheckout\b|\bbidder\b",           "buyer",        0.85),
+    (r"\bseller\b|\blisting\b|\binventory\b",        "seller",       0.85),
+    (r"\blender\b|\bloan\b|\bunderwrite|\bfico\b",   "lender",       0.85),
+    (r"\bescrow\b|\bwallet\b|\bsettlement\b",        "escrow",       0.80),
+    (r"\bauction\b|\blot\b|\breserve\b",             "auction",      0.80),
+    (r"\bdisput(e|es)\b|\barbitrator\b|\bappeal\b",  "disputes",     0.78),
+    (r"\bmechanic\b|\binspection\b|\brepair\b",      "mechanic",     0.80),
+    (r"\binsur(ance|er)\b|\bcarrier\b|\bpolicy\b",   "insurance",    0.78),
+    (r"\badmin\b|\btenant\b|\brole\b|\bpermission\b","admin",        0.75),
+    (r"\bchat\b|\bmessage\b|\bthread\b",             "chat",         0.72),
+    (r"\banalytic(s|s-)\b|\bmetric\b|\bdashboard\b", "analytics",    0.72),
+    (r"\bcontract\b|\bagreement\b|\bsignature\b",    "contract",     0.72),
+    (r"\bgamification\b|\bbadge\b|\blevel\b",        "gamification", 0.70),
+    (r"\bcommon\b|\bshared\b|\butil(s|ity)\b",       "common",       0.65),
+]
+
+CODE_EXTS = {".ts", ".tsx", ".js", ".jsx"}
+
+
+def _read_text(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8", errors="replace")
+    except Exception:
+        try:
+            return path.read_text(encoding="latin-1", errors="replace")
+        except Exception:
+            return ""
+
+
+def heuristic_route(text: str, default_bucket: str | None = None) -> Tuple[str | None, float, str]:
+    """
+    Return (bucket, confidence, reason) based on simple keyword rules.
+    If no rule matches, return (default_bucket, 0.5, reason) if provided, else (None, 0.0, reason).
+    """
+    lower = text.lower()
+    for pattern, bucket, score in BUCKET_RULES:
+        if re.search(pattern, lower):
+            return bucket, score, f"Matched pattern '{pattern}' → '{bucket}'"
+    if default_bucket:
+        return default_bucket, 0.50, f"No strong match; defaulting to '{default_bucket}'"
+    return None, 0.0, "No routing keyword match"
+
+
+def build_markdown_summary(src: Path, text: str, dest_subdir: str | None, confidence: float, reason: str) -> str:
+    # very lightweight “doc” — replace with richer prompt later
+    head = src.name
+    ext  = src.suffix
+    lines = text.splitlines()
+    preview = "\n".join(lines[:20])  # first 20 lines as context
+    md = []
+    md.append(f"# {head}")
+    md.append("")
+    md.append(f"**Detected Type:** `{ext}`  |  **Suggested Dest:** `{dest_subdir or 'unknown'}`  |  **Confidence:** `{confidence:.2f}`")
+    md.append("")
+    md.append("## Purpose (heuristic)")
+    md.append(f"- " + (reason or "No reason"))
+    md.append("")
+    md.append("## Code Preview")
+    md.append("```")
+    md.append(preview)
+    md.append("```")
+    md.append("")
+    md.append("> This summary is heuristic-only. Replace with LLM-backed analysis later.")
+    return "\n".join(md)
+
+
+def review_file(src_path: str, repo_root: str | None = None) -> Dict[str, Any]:
+    """
+    Produce:
+      {
+        "routing": {
+            "suggested_moves": [
+               {"src": "...", "dest": "...", "confidence": 0.87, "reason": "..."}
+            ]
+        },
+        "markdown": "..."
+      }
+    """
+    p = Path(src_path)
+    text = _read_text(p)
+    if not text:
+        return {"routing": {"suggested_moves": []}, "markdown": ""}
+
+    # Heuristic routing
+    bucket, score, reason = heuristic_route(text)
+
+    # Build a destination path inside components if we’re in a frontend repo
+    # FRONTEND_ROOT env var can override (e.g., C:\CFH\frontend)
+    repo_root = repo_root or os.getenv("FRONTEND_ROOT", r"C:\CFH\frontend")
+    dest = None
+    if bucket:
+        try:
+            # if file is within frontend/src/components, mirror subpath; otherwise place under bucket directly
+            components = Path(repo_root) / "src" / "components"
+            suffix_subpath = p.name
+            dest_dir = components / bucket
+            dest = str((dest_dir / suffix_subpath).resolve())
+        except Exception:
+            dest = None
+
+    markdown = build_markdown_summary(p, text, bucket, score, reason)
+
+    move = {
+        "src": str(p),
+        "dest": dest or "",
+        "confidence": float(score),
+        "reason": reason,
+    }
+
+    return {
+        "routing": {"suggested_moves": [move]},
+        "markdown": markdown,
+    }

--- a/app/postprocess.py
+++ b/app/postprocess.py
@@ -1,0 +1,199 @@
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import os
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional, Tuple
+
+# --- config defaults ---
+DOCS_ROOT = Path(r"C:\CFH\docs")
+FRONTEND_ROOT = Path(r"C:\CFH\frontend")
+
+@dataclass
+class MoveSuggestion:
+    src: Path
+    dest: Path
+    confidence: float
+    reason: str
+    doc_mirror: Optional[Path] = None
+
+def _normpath(p: str | Path) -> Path:
+    return Path(str(p)).expanduser().resolve()
+
+def load_artifact(artifact_path: Path) -> Dict[str, Any]:
+    data = json.loads(artifact_path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError("Artifact must be a JSON object")
+    return data
+
+def iter_suggestions(data: Dict[str, Any]) -> Iterable[MoveSuggestion]:
+    """
+    Robustly extract suggestions from your current reviews schema:
+    {
+      "items": [
+        {
+          "src": "C:\\CFH\\frontend\\src\\components\\needsHome\\ARExperience.js",
+          "suggested_moves": [
+            {"dest": "C:\\CFH\\frontend\\src\\components\\seller\\ARExperience.js",
+             "confidence": 0.7, "reason": "..."}
+          ],
+          "doc_mirror": "C:\\CFH\\docs\\frontend\\src\\components\\needsHome\\ARExperience.md"
+        },
+        ...
+      ]
+    }
+    """
+    items = data.get("items") or data.get("entries") or []
+    if not isinstance(items, list):
+        return
+
+    for it in items:
+        try:
+            src = _normpath(it.get("src", ""))
+            if not src:
+                continue
+
+            # take first suggestion if present
+            moves = it.get("suggested_moves") or it.get("moves") or []
+            m = moves[0] if isinstance(moves, list) and moves else None
+            if not m:
+                # nothing to route, still allow doc mirroring
+                doc_mirror = it.get("doc_mirror")
+                yield MoveSuggestion(src=src, dest=src, confidence=0.0, reason="no-suggestion", doc_mirror=_mirror_path_from_item(it))
+                continue
+
+            dest = _normpath(m.get("dest", ""))
+            conf = float(m.get("confidence", 0.0))
+            reason = str(m.get("reason", ""))
+
+            doc_mirror = it.get("doc_mirror") or _mirror_path_from_item(it)  # fallback
+            yield MoveSuggestion(src=src, dest=dest, confidence=conf, reason=reason, doc_mirror=_normpath(doc_mirror) if doc_mirror else None)
+        except Exception:
+            # be resilient: skip malformed entries
+            continue
+
+def _mirror_path_from_item(it: Dict[str, Any]) -> Optional[str]:
+    r"""
+    If 'doc_mirror' is missing, build one from src:
+    C:\CFH\frontend\src\components\foo\Bar.tsx
+      -> C:\CFH\docs\frontend\src\components\foo\Bar.md
+    """
+    src = it.get("src")
+    if not src:
+        return None
+    p = Path(src)
+    # map frontend root to docs\frontend
+    try:
+        rel = p.relative_to(FRONTEND_ROOT)
+        # C:\CFH\docs\frontend\ + rel.with_suffix(".md")
+        return str(DOCS_ROOT / ("frontend" / rel).with_suffix(".md"))
+    except Exception:
+        # generic fallback
+        rel = p.name
+        return str(DOCS_ROOT / (p.stem + ".md"))
+
+def write_audit_csv(rows: List[Tuple[str, str, float, str, bool]], out_csv: Path) -> None:
+    out_csv.parent.mkdir(parents=True, exist_ok=True)
+    with out_csv.open("w", encoding="utf-8", newline="") as f:
+        w = csv.writer(f)
+        w.writerow(["src", "dest", "confidence", "reason", "applied"])
+        for r in rows:
+            w.writerow(r)
+
+def ensure_doc(doc_path: Path, src: Path, reason: str, confidence: float) -> bool:
+    """
+    Write a simple mirrored markdown if not present (or overwrite for demo).
+    """
+    try:
+        doc_path.parent.mkdir(parents=True, exist_ok=True)
+        content = f"""# {src.name}
+
+**Purpose**: Auto-generated mirror doc for `{src}`
+
+- **Suggested location**: `{src.as_posix()}`
+- **Confidence**: {confidence:.2f}
+- **Reason**: {reason}
+
+> Replace this stub with richer documentation as needed.
+"""
+        doc_path.write_text(content, encoding="utf-8")
+        return True
+    except Exception:
+        return False
+
+def apply_moves(sugs: Iterable[MoveSuggestion], threshold: float, do_execute: bool) -> Tuple[List[Tuple[str, str, float, str, bool]], int, int]:
+    audit_rows: List[Tuple[str, str, float, str, bool]] = []
+    moves_applied = 0
+    docs_written  = 0
+
+    for s in sugs:
+        # Always write / refresh a doc mirror if we have a target path
+        if s.doc_mirror:
+            if ensure_doc(_normpath(s.doc_mirror), s.src, s.reason, s.confidence):
+                docs_written += 1
+
+        applied = False
+        if s.confidence >= threshold and s.src != s.dest:
+            if do_execute:
+                try:
+                    s.dest.parent.mkdir(parents=True, exist_ok=True)
+                    # Move the file (overwrite if same name already exists)
+                    if s.dest.exists():
+                        s.dest.unlink()
+                    s.src.replace(s.dest)
+                    applied = True
+                    moves_applied += 1
+                except Exception:
+                    applied = False
+            else:
+                # dry-run: not applying move, but will record as not applied
+                applied = False
+
+        audit_rows.append((
+            str(s.src),
+            str(s.dest),
+            float(s.confidence),
+            s.reason,
+            bool(applied),
+        ))
+
+    return audit_rows, moves_applied, docs_written
+
+def postprocess(artifact_path: str, threshold: float, execute: bool) -> Dict[str, Any]:
+    ap = _normpath(artifact_path)
+    data = load_artifact(ap)
+    sugs = list(iter_suggestions(data))
+
+    # Derive stable CSV name from artifact name (not timestamp now)
+    out_csv = Path("reports") / f"routing_audit_{ap.stem}.csv"
+    rows, moved, docs = apply_moves(sugs, threshold, execute)
+    write_audit_csv(rows, out_csv)
+
+    return {
+        "ok": True,
+        "artifact": str(ap),
+        "audit_csv": str(out_csv).replace("/", "\\"),
+        "rows": len(rows),
+        "moves_applied": moved,
+        "docs_written": docs,
+        "threshold": threshold,
+        "execute_moves": execute,
+    }
+
+def main() -> None:
+    p = argparse.ArgumentParser(description="Post-process AI review artifacts: audit CSV, optional file moves, and docs mirroring.")
+    p.add_argument("artifact", help="Path to reviews_*.json")
+    p.add_argument("--threshold", type=float, default=0.85, help="Minimum confidence to apply a move (docs are written regardless)")
+    p.add_argument("--execute", action="store_true", help="Actually move files (default is dry-run)")
+    p.add_argument("--no-docs", action="store_true", help="(Reserved) – currently docs always write; flag kept for compatibility.")
+    args = p.parse_args()
+
+    res = postprocess(artifact_path=args.artifact, threshold=args.threshold, execute=args.execute)
+    print(json.dumps(res, indent=2))
+
+if __name__ == "__main__":
+    main()

--- a/app/server.py
+++ b/app/server.py
@@ -126,7 +126,7 @@ def _register_health_endpoints(app: FastAPI) -> None:
         # Provider env hint list (still useful for quick setup)
         missing_envs = [k for k in PROVIDER_ENV_HINTS if not _has_key(k)]
         checks["provider_env_missing"] = missing_envs
-
+        checks["providers_enabled"] = [name for name, st in providers.items() if st.get("ok")]
         # --- CFH-specific probe
         checks["cfh_root"] = os.path.exists(r"C:\CFH\frontend")
 
@@ -188,3 +188,6 @@ if __name__ == "__main__":
         log_level=LOG_LEVEL.lower(),
         reload=bool(os.getenv("RELOAD", "0") == "1"),
     )
+
+
+

--- a/app/tools/init.py
+++ b/app/tools/init.py
@@ -1,0 +1,1 @@
+# makes "app.tools" importable as a package

--- a/app/tools/make_reviews.py
+++ b/app/tools/make_reviews.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+import argparse, json, re, time
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+# Simple keyword→destination mapping (tune as you like)
+KEYWORDS: List[Tuple[str, str]] = [
+    (r"\bbuyer\b|\bcheckout\b|\bbid\b",             "buyer"),
+    (r"\bseller\b|\blisting\b|\binventory\b",       "seller"),
+    (r"\blender\b|\bloan\b|\bapr\b|\bcredit\b",     "lender"),
+    (r"\bescrow\b|\bclosing\b|\btrust\b",           "escrow"),
+    (r"\bdispute\b|\barbitration\b|\bjudge\b",      "disputes"),
+    (r"\binspection\b|\bmechanic\b|\bservice\b",    "mechanic"),
+    (r"\binsurance\b|\bpolicy\b|\bclaim\b",         "insurance"),
+    (r"\bmarketplace\b|\bsearch\b|\bresults?\b",    "marketplace"),
+    (r"\bchat\b|\bmessage\b|\bthread\b",            "chat"),
+    (r"\buser\b|\bauth\b|\blogin\b|\bsign[- ]?up\b","auth"),
+    (r"\badmin\b|\bconfig\b|\bsettings?\b",         "admin"),
+    (r"\bfinance\b|\bpayment\b|\binvoice\b",        "finance"),
+]
+
+# files we’ll consider for review
+EXTS = {".ts", ".tsx", ".js", ".jsx"}
+
+def guess_dest(path: Path, text: str) -> Tuple[str, float, str]:
+    """Heuristic: pick a destination folder and confidence with a short reason."""
+    hay = f"{path.name.lower()} {text.lower()}"
+    best: Tuple[str, float, str] = ("common", 0.30, "Default to common (no strong signals).")
+    for pattern, dest in KEYWORDS:
+        if re.search(pattern, hay):
+            # naive scoring: more patterns that match → higher confidence
+            score = 0.7 if dest != "common" else 0.5
+            reason = f'Matched keyword rule "{pattern}" → "{dest}"'
+            if score > best[1]:
+                best = (dest, score, reason)
+    # if file already lives under a known domain, bump confidence
+    parts = [p.lower() for p in path.parts]
+    for _, dest in KEYWORDS:
+        if dest in parts:
+            bump = min(0.2, 1.0 - best[1])
+            best = (dest, best[1] + bump, best[2] + " (directory hint)")
+            break
+    return best
+
+def scan(root: Path, limit: int) -> List[Dict]:
+    files = [p for p in root.rglob("*") if p.is_file() and p.suffix.lower() in EXTS]
+    files.sort(key=lambda p: (p.suffix, p.name.lower()))
+    if limit and limit > 0:
+        files = files[:limit]
+
+    items: List[Dict] = []
+    for p in files:
+        try:
+            txt = p.read_text(encoding="utf-8", errors="ignore")
+        except Exception:
+            txt = ""
+        dest_folder, conf, reason = guess_dest(p, txt)
+        # mirror docs under C:\CFH\docs\frontend\... (same subpath starting at \src\… if present)
+        subpath = None
+        try:
+            idx = [i for i, part in enumerate(p.parts) if part.lower() == "src"]
+            if idx:
+                start = idx[0]
+                subpath = Path(*p.parts[start:])  # src\...\File.tsx
+        except Exception:
+            pass
+
+        items.append({
+            "src": str(p),
+            "suggested_moves": [
+                {
+                    "dest": str(p.parent.parent / dest_folder / p.name)  # move across sibling under components/<dest>/
+                          if ("components" in [x.lower() for x in p.parts]) else str(p),
+                    "confidence": round(float(conf), 3),
+                    "reason": reason,
+                }
+            ],
+            "doc_mirror": str(Path(r"C:\CFH\docs\frontend") / (subpath.as_posix() if subpath else p.name).replace("/", "\\"))[:-len(p.suffix)] + ".md",
+        })
+    return items
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="Generate a reviews JSON artifact from a source tree.")
+    ap.add_argument("--root", required=True, help=r"e.g. C:\CFH\frontend\src\components\needsHome")
+    ap.add_argument("--limit", type=int, default=25, help="Max files to include")
+    args = ap.parse_args()
+
+    root = Path(args.root)
+    if not root.exists() or not root.is_dir():
+        raise SystemExit(f"Root not found or not a directory: {root}")
+
+    items = scan(root, args.limit)
+    payload = {
+        "root": str(root),
+        "generated_at": int(time.time()),
+        "count": len(items),
+        "items": items,
+    }
+    reports = Path("reports"); reports.mkdir(parents=True, exist_ok=True)
+    stamp = time.strftime("%Y%m%d_%H%M%S", time.localtime())
+    out = reports / f"reviews_{stamp}.json"
+    out.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    print(str(out))
+
+if __name__ == "__main__":
+    main()

--- a/reports/convert_batch_20251003_143604.json
+++ b/reports/convert_batch_20251003_143604.json
@@ -1,0 +1,950 @@
+[
+  {
+    "root": "C:\\CFH\\frontend\\src\\components\\admin",
+    "ok": true,
+    "dry_run": false,
+    "converted": [
+      "C:/CFH/frontend/src/components/admin/AdminAuctionOverview.jsx",
+      "C:/CFH/frontend/src/components/admin/AdminAuctionOverview.tsx",
+      "C:/CFH/frontend/src/components/admin/AdminCustomWidgetLibrary.jsx",
+      "C:/CFH/frontend/src/components/admin/AdminCustomWidgetLibrary.tsx",
+      "C:/CFH/frontend/src/components/admin/desktop.ini",
+      "C:/CFH/frontend/src/components/admin/LiveDashboardHealthWidget.jsx",
+      "C:/CFH/frontend/src/components/admin/LiveDashboardHealthWidget.tsx",
+      "C:/CFH/frontend/src/components/admin/analytics/AdminEngagementAnalytics.jsx",
+      "C:/CFH/frontend/src/components/admin/analytics/AdminRoleAnalytics.jsx",
+      "C:/CFH/frontend/src/components/admin/analytics/desktop.ini",
+      "C:/CFH/frontend/src/components/admin/arbitration/AdminArbitrationDashboard.css",
+      "C:/CFH/frontend/src/components/admin/arbitration/AdminArbitrationDashboard.jsx",
+      "C:/CFH/frontend/src/components/admin/arbitration/desktop.ini",
+      "C:/CFH/frontend/src/components/admin/auction/AdminAuctionOverview.jsx",
+      "C:/CFH/frontend/src/components/admin/auction/desktop.ini",
+      "C:/CFH/frontend/src/components/admin/badges/AdminBadgeAuditLog.css",
+      "C:/CFH/frontend/src/components/admin/badges/AdminBadgeAuditLog.jsx",
+      "C:/CFH/frontend/src/components/admin/badges/desktop.ini",
+      "C:/CFH/frontend/src/components/admin/compliance/AdminComplianceDashboard.jsx",
+      "C:/CFH/frontend/src/components/admin/compliance/desktop.ini",
+      "C:/CFH/frontend/src/components/admin/contract/AdminContractTemplates.jsx",
+      "C:/CFH/frontend/src/components/admin/contract/desktop.ini",
+      "C:/CFH/frontend/src/components/admin/dashboard/AdminDashboard.jsx",
+      "C:/CFH/frontend/src/components/admin/dashboard/AdminKPIWidget.jsx",
+      "C:/CFH/frontend/src/components/admin/dashboard/AdminSummaryPanel.jsx",
+      "C:/CFH/frontend/src/components/admin/dashboard/desktop.ini",
+      "C:/CFH/frontend/src/components/admin/disputes/AdminDisputeAnalytics.jsx"
+    ],
+    "skipped": [
+      "C:/CFH/frontend/src/components/admin/analytics",
+      "C:/CFH/frontend/src/components/admin/arbitration",
+      "C:/CFH/frontend/src/components/admin/auction",
+      "C:/CFH/frontend/src/components/admin/badges",
+      "C:/CFH/frontend/src/components/admin/compliance",
+      "C:/CFH/frontend/src/components/admin/contract",
+      "C:/CFH/frontend/src/components/admin/dashboard",
+      "C:/CFH/frontend/src/components/admin/disputes",
+      "C:/CFH/frontend/src/components/admin/escrow",
+      "C:/CFH/frontend/src/components/admin/export",
+      "C:/CFH/frontend/src/components/admin/finance",
+      "C:/CFH/frontend/src/components/admin/health",
+      "C:/CFH/frontend/src/components/admin/insights",
+      "C:/CFH/frontend/src/components/admin/layout",
+      "C:/CFH/frontend/src/components/admin/leaderboard",
+      "C:/CFH/frontend/src/components/admin/logins",
+      "C:/CFH/frontend/src/components/admin/loyalty",
+      "C:/CFH/frontend/src/components/admin/moderation",
+      "C:/CFH/frontend/src/components/admin/notifications",
+      "C:/CFH/frontend/src/components/admin/payments",
+      "C:/CFH/frontend/src/components/admin/reports",
+      "C:/CFH/frontend/src/components/admin/support",
+      "C:/CFH/frontend/src/components/admin/users"
+    ]
+  },
+  {
+    "root": "C:\\CFH\\frontend\\src\\components\\ai",
+    "ok": true,
+    "dry_run": false,
+    "converted": [
+      "C:/CFH/frontend/src/components/ai/AIBadgeOverlay.js",
+      "C:/CFH/frontend/src/components/ai/AIBadgeOverlay.ts",
+      "C:/CFH/frontend/src/components/ai/AIPredictorDashboard.jsx",
+      "C:/CFH/frontend/src/components/ai/AIPredictorDashboard.tsx",
+      "C:/CFH/frontend/src/components/ai/AIScorePanel.js",
+      "C:/CFH/frontend/src/components/ai/AIScorePanel.ts",
+      "C:/CFH/frontend/src/components/ai/BidConfidenceMeter.jsx",
+      "C:/CFH/frontend/src/components/ai/BidConfidenceMeter.tsx",
+      "C:/CFH/frontend/src/components/ai/BidStrategyAdvisor.jsx",
+      "C:/CFH/frontend/src/components/ai/BidStrategyAdvisor.tsx",
+      "C:/CFH/frontend/src/components/ai/desktop.ini",
+      "C:/CFH/frontend/src/components/ai/PredictiveComparison.jsx",
+      "C:/CFH/frontend/src/components/ai/PredictiveComparison.tsx",
+      "C:/CFH/frontend/src/components/ai/SmartInsightsWidget.js",
+      "C:/CFH/frontend/src/components/ai/SmartInsightsWidget.jsx",
+      "C:/CFH/frontend/src/components/ai/SmartInsightsWidget.ts",
+      "C:/CFH/frontend/src/components/ai/SmartInsightsWidget.tsx",
+      "C:/CFH/frontend/src/components/ai/TrustScoreViewer.jsx",
+      "C:/CFH/frontend/src/components/ai/TrustScoreViewer.tsx",
+      "C:/CFH/frontend/src/components/ai/ValuationAssistant.jsx",
+      "C:/CFH/frontend/src/components/ai/ValuationAssistant.tsx",
+      "C:/CFH/frontend/src/components/ai/ValuationLiveFeed.jsx",
+      "C:/CFH/frontend/src/components/ai/ValuationLiveFeed.tsx",
+      "C:/CFH/frontend/src/components/ai/bidding/CompetitiveBiddingInterface.jsx",
+      "C:/CFH/frontend/src/components/ai/bidding/desktop.ini"
+    ],
+    "skipped": [
+      "C:/CFH/frontend/src/components/ai/bidding"
+    ]
+  },
+  {
+    "root": "C:\\CFH\\frontend\\src\\components\\analytics",
+    "ok": true,
+    "dry_run": false,
+    "converted": [
+      "C:/CFH/frontend/src/components/analytics/AnalyticsDashboard.tsx",
+      "C:/CFH/frontend/src/components/analytics/BIIntegrationPanel.tsx",
+      "C:/CFH/frontend/src/components/analytics/ChartWidget.tsx",
+      "C:/CFH/frontend/src/components/analytics/DataTable.tsx",
+      "C:/CFH/frontend/src/components/analytics/desktop.ini",
+      "C:/CFH/frontend/src/components/analytics/FilterPanel.tsx",
+      "C:/CFH/frontend/src/components/analytics/NLPQueryInput.tsx",
+      "C:/CFH/frontend/src/components/analytics/PredictiveGraph.tsx",
+      "C:/CFH/frontend/src/components/analytics/QualityCheckComponent.tsx"
+    ],
+    "skipped": []
+  },
+  {
+    "root": "C:\\CFH\\frontend\\src\\components\\arbitrator",
+    "ok": true,
+    "dry_run": false,
+    "converted": [
+      "C:/CFH/frontend/src/components/arbitrator/ArbitratorAnalyticsPanel.jsx",
+      "C:/CFH/frontend/src/components/arbitrator/ArbitratorAnalyticsPanel.tsx",
+      "C:/CFH/frontend/src/components/arbitrator/ArbitratorDashboard.jsx",
+      "C:/CFH/frontend/src/components/arbitrator/ArbitratorDashboard.tsx",
+      "C:/CFH/frontend/src/components/arbitrator/desktop.ini"
+    ],
+    "skipped": []
+  },
+  {
+    "root": "C:\\CFH\\frontend\\src\\components\\auction",
+    "ok": true,
+    "dry_run": false,
+    "converted": [
+      "C:/CFH/frontend/src/components/auction/AuctionAccessibilityWrapper.jsx",
+      "C:/CFH/frontend/src/components/auction/AuctionAccessibilityWrapper.tsx",
+      "C:/CFH/frontend/src/components/auction/AuctionIntelligenceDashboard.jsx",
+      "C:/CFH/frontend/src/components/auction/AuctionIntelligenceDashboard.tsx",
+      "C:/CFH/frontend/src/components/auction/AuctionItemListing.tsx",
+      "C:/CFH/frontend/src/components/auction/AuctionLiveBidTracker.jsx",
+      "C:/CFH/frontend/src/components/auction/AuctionLiveBidTracker.tsx",
+      "C:/CFH/frontend/src/components/auction/AuctionManagement.tsx",
+      "C:/CFH/frontend/src/components/auction/AuctionPremiumInsightsPanel.jsx",
+      "C:/CFH/frontend/src/components/auction/AuctionPremiumInsightsPanel.tsx",
+      "C:/CFH/frontend/src/components/auction/AuctionSEOHead.jsx",
+      "C:/CFH/frontend/src/components/auction/AuctionSEOHead.tsx",
+      "C:/CFH/frontend/src/components/auction/desktop.ini",
+      "C:/CFH/frontend/src/components/auction/LiveAuctionStream.tsx",
+      "C:/CFH/frontend/src/components/auction/SellerBadgePanel.jsx",
+      "C:/CFH/frontend/src/components/auction/SellerBadgePanel.tsx",
+      "C:/CFH/frontend/src/components/auction/core/6 File.txt",
+      "C:/CFH/frontend/src/components/auction/core/AuctionHistoryTracker.jsx",
+      "C:/CFH/frontend/src/components/auction/core/AuctionListingForm.jsx",
+      "C:/CFH/frontend/src/components/auction/core/desktop.ini",
+      "C:/CFH/frontend/src/components/auction/core/here are the 10 files just was made.txt"
+    ],
+    "skipped": [
+      "C:/CFH/frontend/src/components/auction/core"
+    ]
+  },
+  {
+    "root": "C:\\CFH\\frontend\\src\\components\\auth",
+    "ok": true,
+    "dry_run": false,
+    "converted": [
+      "C:/CFH/frontend/src/components/auth/desktop.ini",
+      "C:/CFH/frontend/src/components/auth/Login.jsx",
+      "C:/CFH/frontend/src/components/auth/Login.tsx",
+      "C:/CFH/frontend/src/components/auth/LoginForm.jsx",
+      "C:/CFH/frontend/src/components/auth/LoginForm.tsx",
+      "C:/CFH/frontend/src/components/auth/ProtectedRoute.js",
+      "C:/CFH/frontend/src/components/auth/ProtectedRoute.ts",
+      "C:/CFH/frontend/src/components/auth/Register.jsx",
+      "C:/CFH/frontend/src/components/auth/Register.tsx",
+      "C:/CFH/frontend/src/components/auth/Unauthorized.jsx",
+      "C:/CFH/frontend/src/components/auth/Unauthorized.tsx"
+    ],
+    "skipped": []
+  },
+  {
+    "root": "C:\\CFH\\frontend\\src\\components\\blockchain",
+    "ok": true,
+    "dry_run": false,
+    "converted": [
+      "C:/CFH/frontend/src/components/blockchain/CryptoPaymentOption.jsx",
+      "C:/CFH/frontend/src/components/blockchain/CryptoPaymentOption.tsx",
+      "C:/CFH/frontend/src/components/blockchain/desktop.ini"
+    ],
+    "skipped": []
+  },
+  {
+    "root": "C:\\CFH\\frontend\\src\\components\\body-shop",
+    "ok": true,
+    "dry_run": false,
+    "converted": [
+      "C:/CFH/frontend/src/components/body-shop/AIDamageSummary.tsx",
+      "C:/CFH/frontend/src/components/body-shop/BodyShopDiscoveryPage.tsx",
+      "C:/CFH/frontend/src/components/body-shop/BodyShopProfileView.tsx",
+      "C:/CFH/frontend/src/components/body-shop/CompareShopsTable.tsx",
+      "C:/CFH/frontend/src/components/body-shop/desktop.ini",
+      "C:/CFH/frontend/src/components/body-shop/EstimateRequestForm.tsx",
+      "C:/CFH/frontend/src/components/body-shop/JobTrackingView.tsx",
+      "C:/CFH/frontend/src/components/body-shop/RepairJourneyShare.tsx",
+      "C:/CFH/frontend/src/components/body-shop/ShopOwnerDashboard.tsx",
+      "C:/CFH/frontend/src/components/body-shop/VirtualShopTour360.tsx"
+    ],
+    "skipped": []
+  },
+  {
+    "root": "C:\\CFH\\frontend\\src\\components\\buyer",
+    "ok": true,
+    "dry_run": false,
+    "converted": [
+      "C:/CFH/frontend/src/components/buyer/AdminSmartAlertEngine.jsx",
+      "C:/CFH/frontend/src/components/buyer/AdminSmartAlertEngine.tsx",
+      "C:/CFH/frontend/src/components/buyer/ARCarPreview.jsx",
+      "C:/CFH/frontend/src/components/buyer/ARCarPreview.tsx",
+      "C:/CFH/frontend/src/components/buyer/AuctionResultsViewer.jsx",
+      "C:/CFH/frontend/src/components/buyer/AuctionResultsViewer.tsx",
+      "C:/CFH/frontend/src/components/buyer/BidAssistantSimulator.jsx",
+      "C:/CFH/frontend/src/components/buyer/BidAssistantSimulator.tsx",
+      "C:/CFH/frontend/src/components/buyer/BuyerAISuggestionEngine.jsx",
+      "C:/CFH/frontend/src/components/buyer/BuyerAISuggestionEngine.tsx",
+      "C:/CFH/frontend/src/components/buyer/BuyerAnalyticsDashboard.jsx",
+      "C:/CFH/frontend/src/components/buyer/BuyerAnalyticsDashboard.tsx",
+      "C:/CFH/frontend/src/components/buyer/BuyerAuctionHistory.js",
+      "C:/CFH/frontend/src/components/buyer/BuyerAuctionHistory.jsx",
+      "C:/CFH/frontend/src/components/buyer/BuyerAuctionHistory.ts",
+      "C:/CFH/frontend/src/components/buyer/BuyerAuctionHistory.tsx",
+      "C:/CFH/frontend/src/components/buyer/BuyerBehaviorTracker.jsx",
+      "C:/CFH/frontend/src/components/buyer/BuyerBehaviorTracker.tsx",
+      "C:/CFH/frontend/src/components/buyer/BuyerBidHistory.jsx",
+      "C:/CFH/frontend/src/components/buyer/BuyerBidHistory.tsx",
+      "C:/CFH/frontend/src/components/buyer/BuyerBidModal.jsx",
+      "C:/CFH/frontend/src/components/buyer/BuyerBidModal.tsx",
+      "C:/CFH/frontend/src/components/buyer/BuyerCarCompare.css",
+      "C:/CFH/frontend/src/components/buyer/BuyerCarCompare.js",
+      "C:/CFH/frontend/src/components/buyer/BuyerCarCompare.ts",
+      "C:/CFH/frontend/src/components/buyer/BuyerCommunityForum.jsx",
+      "C:/CFH/frontend/src/components/buyer/BuyerCommunityForum.tsx",
+      "C:/CFH/frontend/src/components/buyer/BuyerContractPreviewer.jsx",
+      "C:/CFH/frontend/src/components/buyer/BuyerContractPreviewer.tsx",
+      "C:/CFH/frontend/src/components/buyer/BuyerDashboard.css",
+      "C:/CFH/frontend/src/components/buyer/BuyerDashboard.jsx",
+      "C:/CFH/frontend/src/components/buyer/BuyerDeliveryConfirmation.jsx",
+      "C:/CFH/frontend/src/components/buyer/BuyerEmailSettings.jsx",
+      "C:/CFH/frontend/src/components/buyer/BuyerEscrowStatus.jsx",
+      "C:/CFH/frontend/src/components/buyer/BuyerFinancingModal.jsx",
+      "C:/CFH/frontend/src/components/buyer/BuyerInspectionStatus.js",
+      "C:/CFH/frontend/src/components/buyer/BuyerLenderResults.jsx",
+      "C:/CFH/frontend/src/components/buyer/BuyerLoyaltyDashboard.jsx",
+      "C:/CFH/frontend/src/components/buyer/BuyerNotificationCenter.jsx",
+      "C:/CFH/frontend/src/components/buyer/BuyerOnboardingGuide.jsx",
+      "C:/CFH/frontend/src/components/buyer/BuyerPreferencesForm.css",
+      "C:/CFH/frontend/src/components/buyer/BuyerPreferencesForm.jsx",
+      "C:/CFH/frontend/src/components/buyer/BuyerProgressBar.jsx",
+      "C:/CFH/frontend/src/components/buyer/BuyerSearchPreferences.jsx",
+      "C:/CFH/frontend/src/components/buyer/desktop.ini",
+      "C:/CFH/frontend/src/components/buyer/FinancingOffer.js",
+      "C:/CFH/frontend/src/components/buyer/FinancingOptionsChart.jsx",
+      "C:/CFH/frontend/src/components/buyer/ai/AIPredictorDashboard.jsx",
+      "C:/CFH/frontend/src/components/buyer/ai/desktop.ini"
+    ],
+    "skipped": [
+      "C:/CFH/frontend/src/components/buyer/ai"
+    ]
+  },
+  {
+    "root": "C:\\CFH\\frontend\\src\\components\\chat",
+    "ok": true,
+    "dry_run": false,
+    "converted": [
+      "C:/CFH/frontend/src/components/chat/AuditTrail.jsx",
+      "C:/CFH/frontend/src/components/chat/ChatInterface.jsx",
+      "C:/CFH/frontend/src/components/chat/CollaborationChat.jsx",
+      "C:/CFH/frontend/src/components/chat/desktop.ini",
+      "C:/CFH/frontend/src/components/chat/MessageBubble.jsx"
+    ],
+    "skipped": []
+  },
+  {
+    "root": "C:\\CFH\\frontend\\src\\components\\common",
+    "ok": true,
+    "dry_run": false,
+    "converted": [
+      "C:/CFH/frontend/src/components/common/BlockchainSnapshotViewer.jsx",
+      "C:/CFH/frontend/src/components/common/Button.jsx",
+      "C:/CFH/frontend/src/components/common/Card.jsx",
+      "C:/CFH/frontend/src/components/common/ChatAttachmentPreviewer.jsx",
+      "C:/CFH/frontend/src/components/common/ChatAttachmentUploader.jsx",
+      "C:/CFH/frontend/src/components/common/CurrencyConverterWidget.jsx",
+      "C:/CFH/frontend/src/components/common/desktop.ini",
+      "C:/CFH/frontend/src/components/common/DocumentUploader.jsx",
+      "C:/CFH/frontend/src/components/common/ErrorBoundary.jsx",
+      "C:/CFH/frontend/src/components/common/ErrorBoundary.tsx",
+      "C:/CFH/frontend/src/components/common/FeedbackForm.jsx",
+      "C:/CFH/frontend/src/components/common/HeatmapChart.jsx",
+      "C:/CFH/frontend/src/components/common/ImageUploader.jsx",
+      "C:/CFH/frontend/src/components/common/Input.jsx",
+      "C:/CFH/frontend/src/components/common/LanguageSelector.jsx",
+      "C:/CFH/frontend/src/components/common/LoadingSpinner.jsx",
+      "C:/CFH/frontend/src/components/common/Messaging.jsx",
+      "C:/CFH/frontend/src/components/common/MobileUXEnhancer.jsx",
+      "C:/CFH/frontend/src/components/common/MultiLanguageSupport.jsx",
+      "C:/CFH/frontend/src/components/common/Navbar.css",
+      "C:/CFH/frontend/src/components/common/Navbar.jsx",
+      "C:/CFH/frontend/src/components/common/NavbarMobileToggle.jsx",
+      "C:/CFH/frontend/src/components/common/NotificationPreferences.jsx",
+      "C:/CFH/frontend/src/components/common/PDFPreviewModal.jsx",
+      "C:/CFH/frontend/src/components/common/PhotoProofUpload.jsx",
+      "C:/CFH/frontend/src/components/common/PredictiveGraph.jsx",
+      "C:/CFH/frontend/src/components/common/PremiumFeature.jsx",
+      "C:/CFH/frontend/src/components/common/ProtectedRoute.jsx",
+      "C:/CFH/frontend/src/components/common/SEOHead.jsx",
+      "C:/CFH/frontend/src/components/common/ToastManager.jsx",
+      "C:/CFH/frontend/src/components/common/ToastWrapper.jsx",
+      "C:/CFH/frontend/src/components/common/TrustAndAIExplainer.jsx",
+      "C:/CFH/frontend/src/components/common/UnifiedNotificationCenter.jsx",
+      "C:/CFH/frontend/src/components/common/UnreadNotificationBadge.jsx",
+      "C:/CFH/frontend/src/components/common/UserTrustBadges.jsx",
+      "C:/CFH/frontend/src/components/common/ValuationDisplay.jsx",
+      "C:/CFH/frontend/src/components/common/ValuationDisplay.tsx",
+      "C:/CFH/frontend/src/components/common/compliance/ComplianceConsentForm.jsx",
+      "C:/CFH/frontend/src/components/common/compliance/desktop.ini",
+      "C:/CFH/frontend/src/components/common/security/desktop.ini",
+      "C:/CFH/frontend/src/components/common/security/UserSecuritySettings.jsx"
+    ],
+    "skipped": [
+      "C:/CFH/frontend/src/components/common/compliance",
+      "C:/CFH/frontend/src/components/common/security"
+    ]
+  },
+  {
+    "root": "C:\\CFH\\frontend\\src\\components\\community",
+    "ok": true,
+    "dry_run": false,
+    "converted": [
+      "C:/CFH/frontend/src/components/community/CommunityForum.jsx",
+      "C:/CFH/frontend/src/components/community/CommunityLeaderboard.jsx",
+      "C:/CFH/frontend/src/components/community/desktop.ini"
+    ],
+    "skipped": []
+  },
+  {
+    "root": "C:\\CFH\\frontend\\src\\components\\contract",
+    "ok": true,
+    "dry_run": false,
+    "converted": [
+      "C:/CFH/frontend/src/components/contract/ContractPDFViewer.jsx",
+      "C:/CFH/frontend/src/components/contract/ContractSignaturePad.jsx",
+      "C:/CFH/frontend/src/components/contract/ContractSummary.jsx",
+      "C:/CFH/frontend/src/components/contract/ContractViewer.jsx",
+      "C:/CFH/frontend/src/components/contract/desktop.ini"
+    ],
+    "skipped": []
+  },
+  {
+    "root": "C:\\CFH\\frontend\\src\\components\\disputes",
+    "ok": true,
+    "dry_run": false,
+    "converted": [
+      "C:/CFH/frontend/src/components/disputes/desktop.ini",
+      "C:/CFH/frontend/src/components/disputes/DisputeAnalytics.jsx",
+      "C:/CFH/frontend/src/components/disputes/DisputeSimulator.jsx",
+      "C:/CFH/frontend/src/components/disputes/DisputeTimelineViewer.js",
+      "C:/CFH/frontend/src/components/disputes/DownloadCaseBundleButton.js",
+      "C:/CFH/frontend/src/components/disputes/DownloadDisputePDFButton.js",
+      "C:/CFH/frontend/src/components/disputes/JudgeBadgeRenderer.js",
+      "C:/CFH/frontend/src/components/disputes/JudgeLeaderboard.js",
+      "C:/CFH/frontend/src/components/disputes/New folder/desktop.ini",
+      "C:/CFH/frontend/src/components/disputes/styles/desktop.ini"
+    ],
+    "skipped": [
+      "C:/CFH/frontend/src/components/disputes/New folder",
+      "C:/CFH/frontend/src/components/disputes/styles"
+    ]
+  },
+  {
+    "root": "C:\\CFH\\frontend\\src\\components\\equity-hub",
+    "ok": true,
+    "dry_run": false,
+    "converted": [
+      "C:/CFH/frontend/src/components/equity-hub/desktop.ini",
+      "C:/CFH/frontend/src/components/equity-hub/EquityIntelligenceHub.jsx"
+    ],
+    "skipped": []
+  },
+  {
+    "root": "C:\\CFH\\frontend\\src\\components\\escrow",
+    "ok": true,
+    "dry_run": false,
+    "converted": [
+      "C:/CFH/frontend/src/components/escrow/desktop.ini",
+      "C:/CFH/frontend/src/components/escrow/EscrowAuditLogViewer.jsx",
+      "C:/CFH/frontend/src/components/escrow/EscrowConditionChecklist.jsx",
+      "C:/CFH/frontend/src/components/escrow/EscrowDashboard.jsx",
+      "C:/CFH/frontend/src/components/escrow/EscrowDocumentGallery.jsx",
+      "C:/CFH/frontend/src/components/escrow/EscrowDocumentUploader.jsx",
+      "C:/CFH/frontend/src/components/escrow/EscrowInfoPanel.js",
+      "C:/CFH/frontend/src/components/escrow/EscrowOfficerDashboard.jsx",
+      "C:/CFH/frontend/src/components/escrow/EscrowOfficerHook.js",
+      "C:/CFH/frontend/src/components/escrow/EscrowOfficerPremiumPanel.jsx",
+      "C:/CFH/frontend/src/components/escrow/EscrowPaymentManager.jsx",
+      "C:/CFH/frontend/src/components/escrow/EscrowPaymentManagerNeedsChecking.jsx",
+      "C:/CFH/frontend/src/components/escrow/EscrowRoleGuard.jsx",
+      "C:/CFH/frontend/src/components/escrow/EscrowSEOHead.jsx",
+      "C:/CFH/frontend/src/components/escrow/EscrowStatusNotifier.jsx",
+      "C:/CFH/frontend/src/components/escrow/EscrowStatusTracker.jsx",
+      "C:/CFH/frontend/src/components/escrow/EscrowStatusViewer.jsx",
+      "C:/CFH/frontend/src/components/escrow/EscrowSyncAdminPanel.jsx",
+      "C:/CFH/frontend/src/components/escrow/EscrowTransaction.tsx",
+      "C:/CFH/frontend/src/components/escrow/EscrowTransactionDetailModal.jsx",
+      "C:/CFH/frontend/src/components/escrow/EscrowTransactionPDFExporter.js",
+      "C:/CFH/frontend/src/components/escrow/EscrowTransactionSearch.jsx",
+      "C:/CFH/frontend/src/components/escrow/EscrowUserAnalyticsPanel.jsx"
+    ],
+    "skipped": []
+  },
+  {
+    "root": "C:\\CFH\\frontend\\src\\components\\finance",
+    "ok": true,
+    "dry_run": false,
+    "converted": [
+      "C:/CFH/frontend/src/components/finance/desktop.ini",
+      "C:/CFH/frontend/src/components/finance/FinanceRiskAssessment.jsx"
+    ],
+    "skipped": []
+  },
+  {
+    "root": "C:\\CFH\\frontend\\src\\components\\gamification",
+    "ok": true,
+    "dry_run": false,
+    "converted": [
+      "C:/CFH/frontend/src/components/gamification/AchievementPopup.jsx",
+      "C:/CFH/frontend/src/components/gamification/BadgeStorefront.jsx",
+      "C:/CFH/frontend/src/components/gamification/desktop.ini",
+      "C:/CFH/frontend/src/components/gamification/LeaderboardWidget.jsx"
+    ],
+    "skipped": []
+  },
+  {
+    "root": "C:\\CFH\\frontend\\src\\components\\guest",
+    "ok": true,
+    "dry_run": false,
+    "converted": [
+      "C:/CFH/frontend/src/components/guest/desktop.ini",
+      "C:/CFH/frontend/src/components/guest/GuestDashboard.jsx"
+    ],
+    "skipped": []
+  },
+  {
+    "root": "C:\\CFH\\frontend\\src\\components\\hauler",
+    "ok": true,
+    "dry_run": false,
+    "converted": [
+      "C:/CFH/frontend/src/components/hauler/BookingModal.jsx",
+      "C:/CFH/frontend/src/components/hauler/BookingModal.tsx",
+      "C:/CFH/frontend/src/components/hauler/CarTransportCoordination.jsx",
+      "C:/CFH/frontend/src/components/hauler/desktop.ini",
+      "C:/CFH/frontend/src/components/hauler/GeoStatusPanel.js",
+      "C:/CFH/frontend/src/components/hauler/HaulerAuctionDelivery.jsx",
+      "C:/CFH/frontend/src/components/hauler/HaulerCommunityBoard.jsx",
+      "C:/CFH/frontend/src/components/hauler/HaulerDashboard.css",
+      "C:/CFH/frontend/src/components/hauler/HaulerJobUploadForm.js",
+      "C:/CFH/frontend/src/components/hauler/HaulerLoyaltyDashboard.jsx",
+      "C:/CFH/frontend/src/components/hauler/HaulerReputationTracker.js",
+      "C:/CFH/frontend/src/components/hauler/hauler_job_details_page.tsx",
+      "C:/CFH/frontend/src/components/hauler/MissionCompletionLeaderboard.jsx",
+      "C:/CFH/frontend/src/components/hauler/PhotoEvidenceViewer.js",
+      "C:/CFH/frontend/src/components/hauler/RouteRiskAnalysis.jsx",
+      "C:/CFH/frontend/src/components/hauler/TransporterJobStatus.js",
+      "C:/CFH/frontend/src/components/hauler/TransporterLiveTracking.js",
+      "C:/CFH/frontend/src/components/hauler/__tests__/desktop.ini",
+      "C:/CFH/frontend/src/components/hauler/__tests__/hauler_job_details_page_test.ts",
+      "C:/CFH/frontend/src/components/hauler/__tests__/user_profile_routes_test.ts"
+    ],
+    "skipped": [
+      "C:/CFH/frontend/src/components/hauler/__tests__"
+    ]
+  },
+  {
+    "root": "C:\\CFH\\frontend\\src\\components\\inspections",
+    "ok": true,
+    "dry_run": false,
+    "converted": [
+      "C:/CFH/frontend/src/components/inspections/desktop.ini",
+      "C:/CFH/frontend/src/components/inspections/InspectionIndexPage.js",
+      "C:/CFH/frontend/src/components/inspections/InspectionReportList.js",
+      "C:/CFH/frontend/src/components/inspections/InspectionReportViewerPage.js",
+      "C:/CFH/frontend/src/components/inspections/InspectionSearchBar.js",
+      "C:/CFH/frontend/src/components/inspections/PhotoUpload.tsx",
+      "C:/CFH/frontend/src/components/inspections/VRInspection.js"
+    ],
+    "skipped": []
+  },
+  {
+    "root": "C:\\CFH\\frontend\\src\\components\\insurance",
+    "ok": true,
+    "dry_run": false,
+    "converted": [
+      "C:/CFH/frontend/src/components/insurance/ClaimsProcessor.jsx",
+      "C:/CFH/frontend/src/components/insurance/desktop.ini",
+      "C:/CFH/frontend/src/components/insurance/InsuranceAIModelPerformance.jsx",
+      "C:/CFH/frontend/src/components/insurance/InsuranceClaimsAnalytics.jsx",
+      "C:/CFH/frontend/src/components/insurance/InsuranceClaimsProcessor.jsx",
+      "C:/CFH/frontend/src/components/insurance/InsuranceComparison.js",
+      "C:/CFH/frontend/src/components/insurance/InsuranceDashboard.js",
+      "C:/CFH/frontend/src/components/insurance/InsuranceOfficerDashboard.jsx",
+      "C:/CFH/frontend/src/components/insurance/InsurancePolicyManager.jsx",
+      "C:/CFH/frontend/src/components/insurance/InsuranceRoleGuard.jsx",
+      "C:/CFH/frontend/src/components/insurance/InsuranceSEOHead.jsx",
+      "C:/CFH/frontend/src/components/insurance/InsuranceUnderwritingChecklist.jsx",
+      "C:/CFH/frontend/src/components/insurance/InsurerInsightsChart.jsx",
+      "C:/CFH/frontend/src/components/insurance/PolicyReviewQueue.js",
+      "C:/CFH/frontend/src/components/insurance/QuoteSubmissionForm.js"
+    ],
+    "skipped": []
+  },
+  {
+    "root": "C:\\CFH\\frontend\\src\\components\\internal",
+    "ok": true,
+    "dry_run": false,
+    "converted": [
+      "C:/CFH/frontend/src/components/internal/desktop.ini",
+      "C:/CFH/frontend/src/components/internal/TestRunnerDashboard.jsx"
+    ],
+    "skipped": []
+  },
+  {
+    "root": "C:\\CFH\\frontend\\src\\components\\judge",
+    "ok": true,
+    "dry_run": false,
+    "converted": [
+      "C:/CFH/frontend/src/components/judge/ArbitrationDashboard.js",
+      "C:/CFH/frontend/src/components/judge/desktop.ini",
+      "C:/CFH/frontend/src/components/judge/DisputeAnalyticsPanel.jsx",
+      "C:/CFH/frontend/src/components/judge/JudgeDashboard.js",
+      "C:/CFH/frontend/src/components/judge/JudgePanelControls.jsx",
+      "C:/CFH/frontend/src/components/judge/SmartVerdictHint.jsx",
+      "C:/CFH/frontend/src/components/judge/components/desktop.ini",
+      "C:/CFH/frontend/src/components/judge/components/DisputeCard.js"
+    ],
+    "skipped": [
+      "C:/CFH/frontend/src/components/judge/components"
+    ]
+  },
+  {
+    "root": "C:\\CFH\\frontend\\src\\components\\lender",
+    "ok": true,
+    "dry_run": false,
+    "converted": [
+      "C:/CFH/frontend/src/components/lender/BidDetailViewer.js",
+      "C:/CFH/frontend/src/components/lender/contractReviewController.js",
+      "C:/CFH/frontend/src/components/lender/desktop.ini",
+      "C:/CFH/frontend/src/components/lender/FinancingOffer.js",
+      "C:/CFH/frontend/src/components/lender/LenderAnalyticsDashboard.js",
+      "C:/CFH/frontend/src/components/lender/LenderBidDetailCard.js",
+      "C:/CFH/frontend/src/components/lender/LenderBiddingDashboard.css",
+      "C:/CFH/frontend/src/components/lender/LenderBiddingDashboard.js",
+      "C:/CFH/frontend/src/components/lender/LenderContractReview.js",
+      "C:/CFH/frontend/src/components/lender/LenderContractSummary.js",
+      "C:/CFH/frontend/src/components/lender/LenderDashboard.js",
+      "C:/CFH/frontend/src/components/lender/LenderDashboard.jsx",
+      "C:/CFH/frontend/src/components/lender/LenderExportCenter.js",
+      "C:/CFH/frontend/src/components/lender/LenderExportPanel.js",
+      "C:/CFH/frontend/src/components/lender/LenderExportPanel.jsx",
+      "C:/CFH/frontend/src/components/lender/LenderInsightsPanel.js",
+      "C:/CFH/frontend/src/components/lender/LenderLoyaltyDashboard.jsx",
+      "C:/CFH/frontend/src/components/lender/LenderMatchListView.js",
+      "C:/CFH/frontend/src/components/lender/LenderMatchPreviewCard.js",
+      "C:/CFH/frontend/src/components/lender/LenderOnboardingForm.js",
+      "C:/CFH/frontend/src/components/lender/LenderPreApprovalDashboard.js",
+      "C:/CFH/frontend/src/components/lender/LenderProfilePage.js",
+      "C:/CFH/frontend/src/components/lender/lenderReputationController.js",
+      "C:/CFH/frontend/src/components/lender/LenderReputationSummary.js",
+      "C:/CFH/frontend/src/components/lender/LenderReputationTracker.js",
+      "C:/CFH/frontend/src/components/lender/LenderReviewDashboard.js",
+      "C:/CFH/frontend/src/components/lender/LenderTermsHistoryViewer.jsx",
+      "C:/CFH/frontend/src/components/lender/LoanComparison.css",
+      "C:/CFH/frontend/src/components/lender/LoanComparison.js"
+    ],
+    "skipped": []
+  },
+  {
+    "root": "C:\\CFH\\frontend\\src\\components\\maas",
+    "ok": true,
+    "dry_run": false,
+    "converted": [
+      "C:/CFH/frontend/src/components/maas/BulkTitleTransfer.jsx",
+      "C:/CFH/frontend/src/components/maas/desktop.ini",
+      "C:/CFH/frontend/src/components/maas/MaaSIntegration.jsx"
+    ],
+    "skipped": []
+  },
+  {
+    "root": "C:\\CFH\\frontend\\src\\components\\marketplace",
+    "ok": true,
+    "dry_run": false,
+    "converted": [
+      "C:/CFH/frontend/src/components/marketplace/ActivityOverview.jsx",
+      "C:/CFH/frontend/src/components/marketplace/BadgeDisplayPanel.jsx",
+      "C:/CFH/frontend/src/components/marketplace/BestFinancingDealCard.jsx",
+      "C:/CFH/frontend/src/components/marketplace/desktop.ini",
+      "C:/CFH/frontend/src/components/marketplace/HaulerSummaryCard.jsx",
+      "C:/CFH/frontend/src/components/marketplace/MarketplaceComponent.tsx",
+      "C:/CFH/frontend/src/components/marketplace/MarketplaceInsightsDashboard.jsx"
+    ],
+    "skipped": []
+  },
+  {
+    "root": "C:\\CFH\\frontend\\src\\components\\mechanic",
+    "ok": true,
+    "dry_run": false,
+    "converted": [
+      "C:/CFH/frontend/src/components/mechanic/AIDiagnosticsAssistant.jsx",
+      "C:/CFH/frontend/src/components/mechanic/desktop.ini",
+      "C:/CFH/frontend/src/components/mechanic/EscrowStatusSync.jsx",
+      "C:/CFH/frontend/src/components/mechanic/HaulerCollaboration.jsx",
+      "C:/CFH/frontend/src/components/mechanic/InspectionForm.js",
+      "C:/CFH/frontend/src/components/mechanic/InspectionPhotoPreviewer.jsx",
+      "C:/CFH/frontend/src/components/mechanic/InspectionReportPanel.jsx",
+      "C:/CFH/frontend/src/components/mechanic/InspectionReportViewer.js",
+      "C:/CFH/frontend/src/components/mechanic/LiveInspectionTaskFeed.jsx",
+      "C:/CFH/frontend/src/components/mechanic/MechanicBadgeConfettiPanel.jsx",
+      "C:/CFH/frontend/src/components/mechanic/MechanicBadgeDisplayPanel.jsx",
+      "C:/CFH/frontend/src/components/mechanic/MechanicBadgeImpactTracker.jsx",
+      "C:/CFH/frontend/src/components/mechanic/MechanicBadgeLeaderboard.jsx",
+      "C:/CFH/frontend/src/components/mechanic/MechanicBadgeProgressTracker.jsx",
+      "C:/CFH/frontend/src/components/mechanic/MechanicDashboard.jsx",
+      "C:/CFH/frontend/src/components/mechanic/MechanicInspectionDetail.js",
+      "C:/CFH/frontend/src/components/mechanic/MechanicInspectionForm.jsx",
+      "C:/CFH/frontend/src/components/mechanic/MechanicJobStatusBadge.jsx",
+      "C:/CFH/frontend/src/components/mechanic/MechanicMilestoneTracker.jsx",
+      "C:/CFH/frontend/src/components/mechanic/MechanicProgressReviewBoard.jsx",
+      "C:/CFH/frontend/src/components/mechanic/MechanicRepairHistoryTimeline.jsx",
+      "C:/CFH/frontend/src/components/mechanic/MechanicReportDashboard.jsx",
+      "C:/CFH/frontend/src/components/mechanic/MechanicReviewPanel.jsx",
+      "C:/CFH/frontend/src/components/mechanic/MechanicRewardConfetti.jsx",
+      "C:/CFH/frontend/src/components/mechanic/MechanicShiftPlanner.jsx",
+      "C:/CFH/frontend/src/components/mechanic/MechanicTaskHistoryTable.jsx",
+      "C:/CFH/frontend/src/components/mechanic/MechanicTaskOutcomeReporter.jsx",
+      "C:/CFH/frontend/src/components/mechanic/MechanicTaskReporter.jsx",
+      "C:/CFH/frontend/src/components/mechanic/MechanicTimelineCelebration.jsx",
+      "C:/CFH/frontend/src/components/mechanic/MechanicVRPhotoUploader.jsx",
+      "C:/CFH/frontend/src/components/mechanic/MechanicVRPreviewViewer.jsx",
+      "C:/CFH/frontend/src/components/mechanic/PremiumBadgeHintCard.jsx",
+      "C:/CFH/frontend/src/components/mechanic/RepairScheduler.jsx",
+      "C:/CFH/frontend/src/components/mechanic/SharedReportViewer.jsx",
+      "C:/CFH/frontend/src/components/mechanic/TaskCompletionButton.jsx",
+      "C:/CFH/frontend/src/components/mechanic/VehicleHealthTrendCharts.jsx",
+      "C:/CFH/frontend/src/components/mechanic/VehicleInspectionModule.jsx",
+      "C:/CFH/frontend/src/components/mechanic/VINDecoder.jsx",
+      "C:/CFH/frontend/src/components/mechanic/VRInspectionViewer.jsx"
+    ],
+    "skipped": []
+  },
+  {
+    "root": "C:\\CFH\\frontend\\src\\components\\mobile",
+    "ok": true,
+    "dry_run": false,
+    "converted": [
+      "C:/CFH/frontend/src/components/mobile/desktop.ini",
+      "C:/CFH/frontend/src/components/mobile/MobileAnalytics.jsx",
+      "C:/CFH/frontend/src/components/mobile/MobileAuctionView.jsx"
+    ],
+    "skipped": []
+  },
+  {
+    "root": "C:\\CFH\\frontend\\src\\components\\mock",
+    "ok": true,
+    "dry_run": false,
+    "converted": [
+      "C:/CFH/frontend/src/components/mock/desktop.ini",
+      "C:/CFH/frontend/src/components/mock/MockComponent.jsx"
+    ],
+    "skipped": []
+  },
+  {
+    "root": "C:\\CFH\\frontend\\src\\components\\needsHome",
+    "ok": true,
+    "dry_run": false,
+    "converted": [
+      "C:/CFH/frontend/src/components/needsHome/ARExperience.js",
+      "C:/CFH/frontend/src/components/needsHome/AutomationAgent.js",
+      "C:/CFH/frontend/src/components/needsHome/BadgeDisplay.js",
+      "C:/CFH/frontend/src/components/needsHome/BulkUpload.css",
+      "C:/CFH/frontend/src/components/needsHome/BulkUpload.js",
+      "C:/CFH/frontend/src/components/needsHome/Button.js",
+      "C:/CFH/frontend/src/components/needsHome/CommunityDashboard.css",
+      "C:/CFH/frontend/src/components/needsHome/CommunityDashboard.js",
+      "C:/CFH/frontend/src/components/needsHome/CommunityHub.js",
+      "C:/CFH/frontend/src/components/needsHome/CommunityHubEnhanced.js",
+      "C:/CFH/frontend/src/components/needsHome/CommunityModeratorDashboard.js",
+      "C:/CFH/frontend/src/components/needsHome/ComplianceReviewerDashboard.js",
+      "C:/CFH/frontend/src/components/needsHome/CrossBorderFinancing.js",
+      "C:/CFH/frontend/src/components/needsHome/desktop.ini",
+      "C:/CFH/frontend/src/components/needsHome/DynamicPricing.js",
+      "C:/CFH/frontend/src/components/needsHome/FinancingCalculator.css",
+      "C:/CFH/frontend/src/components/needsHome/FinancingCalculator.js",
+      "C:/CFH/frontend/src/components/needsHome/Forum.css",
+      "C:/CFH/frontend/src/components/needsHome/FraudDetection.js",
+      "C:/CFH/frontend/src/components/needsHome/integrationReportValidation.js",
+      "C:/CFH/frontend/src/components/needsHome/Leaderboard.css",
+      "C:/CFH/frontend/src/components/needsHome/Leaderboard.js",
+      "C:/CFH/frontend/src/components/needsHome/LeaveReview.css",
+      "C:/CFH/frontend/src/components/needsHome/LeaveReview.js",
+      "C:/CFH/frontend/src/components/needsHome/LoadingSpinner.js",
+      "C:/CFH/frontend/src/components/needsHome/LoanComparison.js",
+      "C:/CFH/frontend/src/components/needsHome/LoyaltyQuests.js",
+      "C:/CFH/frontend/src/components/needsHome/MarketplaceInsights.js",
+      "C:/CFH/frontend/src/components/needsHome/Messaging.css",
+      "C:/CFH/frontend/src/components/needsHome/Messaging.js",
+      "C:/CFH/frontend/src/components/needsHome/Navbar.js",
+      "C:/CFH/frontend/src/components/needsHome/NotificationCenter.css",
+      "C:/CFH/frontend/src/components/needsHome/NotificationCenter.js",
+      "C:/CFH/frontend/src/components/needsHome/PaymentForm.js",
+      "C:/CFH/frontend/src/components/needsHome/ProtectedRoute.js",
+      "C:/CFH/frontend/src/components/needsHome/ReferralAnalytics.js",
+      "C:/CFH/frontend/src/components/needsHome/Register.js",
+      "C:/CFH/frontend/src/components/needsHome/RegisterForm.js",
+      "C:/CFH/frontend/src/components/needsHome/ReputationBadgeTier.css",
+      "C:/CFH/frontend/src/components/needsHome/ReputationBadgeTier.js",
+      "C:/CFH/frontend/src/components/needsHome/RoleActivityCharts.css",
+      "C:/CFH/frontend/src/components/needsHome/RoleActivityCharts.js",
+      "C:/CFH/frontend/src/components/needsHome/RoleSwitchWrapper.js",
+      "C:/CFH/frontend/src/components/needsHome/SellerCreateListing.js",
+      "C:/CFH/frontend/src/components/needsHome/SellerDashboard.js",
+      "C:/CFH/frontend/src/components/needsHome/SmartRecommendations.css",
+      "C:/CFH/frontend/src/components/needsHome/SmartRecommendations.js",
+      "C:/CFH/frontend/src/components/needsHome/SupportCenter.js",
+      "C:/CFH/frontend/src/components/needsHome/TradeInForm.js",
+      "C:/CFH/frontend/src/components/needsHome/useAuth.js"
+    ],
+    "skipped": []
+  },
+  {
+    "root": "C:\\CFH\\frontend\\src\\components\\notifications",
+    "ok": true,
+    "dry_run": false,
+    "converted": [
+      "C:/CFH/frontend/src/components/notifications/AdminEmailNotifications.jsx",
+      "C:/CFH/frontend/src/components/notifications/desktop.ini",
+      "C:/CFH/frontend/src/components/notifications/NotificationCenter.jsx",
+      "C:/CFH/frontend/src/components/notifications/NotificationsComponent.tsx",
+      "C:/CFH/frontend/src/components/notifications/UnreadNotificationBadge.jsx"
+    ],
+    "skipped": []
+  },
+  {
+    "root": "C:\\CFH\\frontend\\src\\components\\officer",
+    "ok": true,
+    "dry_run": false,
+    "converted": [
+      "C:/CFH/frontend/src/components/officer/desktop.ini",
+      "C:/CFH/frontend/src/components/officer/DisputeRadarWidget.jsx"
+    ],
+    "skipped": []
+  },
+  {
+    "root": "C:\\CFH\\frontend\\src\\components\\onboarding",
+    "ok": true,
+    "dry_run": false,
+    "converted": [
+      "C:/CFH/frontend/src/components/onboarding/desktop.ini",
+      "C:/CFH/frontend/src/components/onboarding/FinancierOnboarding.js",
+      "C:/CFH/frontend/src/components/onboarding/OnboardingGuide.js",
+      "C:/CFH/frontend/src/components/onboarding/OnboardingTrigger.jsx",
+      "C:/CFH/frontend/src/components/onboarding/OnboardingWizard.jsx"
+    ],
+    "skipped": []
+  },
+  {
+    "root": "C:\\CFH\\frontend\\src\\components\\partner",
+    "ok": true,
+    "dry_run": false,
+    "converted": [
+      "C:/CFH/frontend/src/components/partner/desktop.ini",
+      "C:/CFH/frontend/src/components/partner/PartnerPortal.jsx"
+    ],
+    "skipped": []
+  },
+  {
+    "root": "C:\\CFH\\frontend\\src\\components\\premium",
+    "ok": true,
+    "dry_run": false,
+    "converted": [
+      "C:/CFH/frontend/src/components/premium/BadgeDisplay.jsx",
+      "C:/CFH/frontend/src/components/premium/desktop.ini",
+      "C:/CFH/frontend/src/components/premium/LeaderboardDisplay.jsx",
+      "C:/CFH/frontend/src/components/premium/LiveStreamViewer.jsx",
+      "C:/CFH/frontend/src/components/premium/PredictiveAssistant.jsx",
+      "C:/CFH/frontend/src/components/premium/PremiumDashboard.jsx",
+      "C:/CFH/frontend/src/components/premium/PricingInsights.jsx",
+      "C:/CFH/frontend/src/components/premium/RecommendedAuctions.jsx",
+      "C:/CFH/frontend/src/components/premium/SupportChatWidget.jsx",
+      "C:/CFH/frontend/src/components/premium/SustainabilityMetrics.jsx",
+      "C:/CFH/frontend/src/components/premium/VRTourLauncher.jsx"
+    ],
+    "skipped": []
+  },
+  {
+    "root": "C:\\CFH\\frontend\\src\\components\\recommendations",
+    "ok": true,
+    "dry_run": false,
+    "converted": [
+      "C:/CFH/frontend/src/components/recommendations/AdvancedSmartRecommendations.js",
+      "C:/CFH/frontend/src/components/recommendations/AIInsights.js",
+      "C:/CFH/frontend/src/components/recommendations/AIRecommendations.css",
+      "C:/CFH/frontend/src/components/recommendations/AIRecommendations.js",
+      "C:/CFH/frontend/src/components/recommendations/desktop.ini",
+      "C:/CFH/frontend/src/components/recommendations/loanRecommendationController.js",
+      "C:/CFH/frontend/src/components/recommendations/SustainabilityScoring.js"
+    ],
+    "skipped": []
+  },
+  {
+    "root": "C:\\CFH\\frontend\\src\\components\\seller",
+    "ok": true,
+    "dry_run": false,
+    "converted": [
+      "C:/CFH/frontend/src/components/seller/AISuggestionEngine.js",
+      "C:/CFH/frontend/src/components/seller/CreateListingForm.js",
+      "C:/CFH/frontend/src/components/seller/desktop.ini",
+      "C:/CFH/frontend/src/components/seller/SellerAchievementTracker.jsx",
+      "C:/CFH/frontend/src/components/seller/SellerActionPanel.jsx",
+      "C:/CFH/frontend/src/components/seller/SellerActivityInsights.jsx",
+      "C:/CFH/frontend/src/components/seller/SellerActivityTimeline.jsx",
+      "C:/CFH/frontend/src/components/seller/SellerAnalyticsChart.jsx",
+      "C:/CFH/frontend/src/components/seller/SellerAuctionForm.jsx",
+      "C:/CFH/frontend/src/components/seller/SellerAuctionStarter.jsx",
+      "C:/CFH/frontend/src/components/seller/SellerAuctionStatus.jsx",
+      "C:/CFH/frontend/src/components/seller/SellerBadgesPage.jsx",
+      "C:/CFH/frontend/src/components/seller/SellerContractManager.jsx",
+      "C:/CFH/frontend/src/components/seller/SellerCreateListing.jsx",
+      "C:/CFH/frontend/src/components/seller/SellerCustomerTestimonials.jsx",
+      "C:/CFH/frontend/src/components/seller/SellerDashboard.css",
+      "C:/CFH/frontend/src/components/seller/SellerDashboard.jsx",
+      "C:/CFH/frontend/src/components/seller/SellerDeepAnalytics.jsx",
+      "C:/CFH/frontend/src/components/seller/SellerDisputeCenter.jsx",
+      "C:/CFH/frontend/src/components/seller/SellerDocVault.jsx",
+      "C:/CFH/frontend/src/components/seller/SellerEditListing.jsx",
+      "C:/CFH/frontend/src/components/seller/SellerEmailSettings.jsx",
+      "C:/CFH/frontend/src/components/seller/SellerEngagementLeaderboard.jsx",
+      "C:/CFH/frontend/src/components/seller/SellerEscrowStatus.jsx",
+      "C:/CFH/frontend/src/components/seller/SellerExperienceLevel.jsx",
+      "C:/CFH/frontend/src/components/seller/SellerExportPanel.jsx",
+      "C:/CFH/frontend/src/components/seller/SellerGalleryManager.jsx",
+      "C:/CFH/frontend/src/components/seller/SellerInventoryList.jsx",
+      "C:/CFH/frontend/src/components/seller/SellerKPIWidget.jsx",
+      "C:/CFH/frontend/src/components/seller/SellerListingEdit.jsx",
+      "C:/CFH/frontend/src/components/seller/SellerListingGallery.jsx",
+      "C:/CFH/frontend/src/components/seller/SellerManageListings.jsx",
+      "C:/CFH/frontend/src/components/seller/SellerMarketTrendInsights.jsx",
+      "C:/CFH/frontend/src/components/seller/SellerMilestoneCelebrator.jsx",
+      "C:/CFH/frontend/src/components/seller/SellerMissionCenter.jsx",
+      "C:/CFH/frontend/src/components/seller/SellerNotificationCenter.jsx",
+      "C:/CFH/frontend/src/components/seller/SellerNotifications.jsx",
+      "C:/CFH/frontend/src/components/seller/SellerOfferTracker.jsx",
+      "C:/CFH/frontend/src/components/seller/SellerOnboardingGuide.jsx",
+      "C:/CFH/frontend/src/components/seller/SellerPerformanceComparison.jsx",
+      "C:/CFH/frontend/src/components/seller/SellerPricingTool.css",
+      "C:/CFH/frontend/src/components/seller/SellerPricingTool.js",
+      "C:/CFH/frontend/src/components/seller/SellerProfileCard.jsx",
+      "C:/CFH/frontend/src/components/seller/SellerReputationDashboard.jsx",
+      "C:/CFH/frontend/src/components/seller/SellerReviewSummary.jsx",
+      "C:/CFH/frontend/src/components/seller/SellerRewardsBadgeDisplay.jsx",
+      "C:/CFH/frontend/src/components/seller/SellerSalesAnalytics.jsx",
+      "C:/CFH/frontend/src/components/seller/SellerSalesFunnelOverview.jsx",
+      "C:/CFH/frontend/src/components/seller/SellerSmartBadgeSystem.jsx",
+      "C:/CFH/frontend/src/components/seller/SellerSuccessTips.jsx"
+    ],
+    "skipped": []
+  },
+  {
+    "root": "C:\\CFH\\frontend\\src\\components\\storage",
+    "ok": true,
+    "dry_run": false,
+    "converted": [
+      "C:/CFH/frontend/src/components/storage/desktop.ini",
+      "C:/CFH/frontend/src/components/storage/StorageARNavigationApp.jsx",
+      "C:/CFH/frontend/src/components/storage/StorageAssignmentForm.jsx",
+      "C:/CFH/frontend/src/components/storage/StorageHostDashboard.js",
+      "C:/CFH/frontend/src/components/storage/StorageInventoryTracker.jsx"
+    ],
+    "skipped": []
+  },
+  {
+    "root": "C:\\CFH\\frontend\\src\\components\\support",
+    "ok": true,
+    "dry_run": false,
+    "converted": [
+      "C:/CFH/frontend/src/components/support/desktop.ini",
+      "C:/CFH/frontend/src/components/support/File SellerAuctionStatus.jsx.txt",
+      "C:/CFH/frontend/src/components/support/SupportChatWidget.jsx",
+      "C:/CFH/frontend/src/components/support/SupportDashboard.jsx",
+      "C:/CFH/frontend/src/components/support/SupportTicketAnalytics.jsx",
+      "C:/CFH/frontend/src/components/support/SupportTicketForm.jsx",
+      "C:/CFH/frontend/src/components/support/SupportTicketFormInLineFromGrok.jsx"
+    ],
+    "skipped": []
+  },
+  {
+    "root": "C:\\CFH\\frontend\\src\\components\\tinting",
+    "ok": true,
+    "dry_run": false,
+    "converted": [
+      "C:/CFH/frontend/src/components/tinting/desktop.ini",
+      "C:/CFH/frontend/src/components/tinting/TintingServiceDiscovery.tsx",
+      "C:/CFH/frontend/src/components/tinting/WindowTintingScheduler.tsx"
+    ],
+    "skipped": []
+  },
+  {
+    "root": "C:\\CFH\\frontend\\src\\components\\title",
+    "ok": true,
+    "dry_run": false,
+    "converted": [
+      "C:/CFH/frontend/src/components/title/BulkTitleTransfer.jsx",
+      "C:/CFH/frontend/src/components/title/desktop.ini",
+      "C:/CFH/frontend/src/components/title/TitleAgentDashboard.js",
+      "C:/CFH/frontend/src/components/title/TitleTransferQueue.js",
+      "C:/CFH/frontend/src/components/title/TitleVerificationForm.js"
+    ],
+    "skipped": []
+  },
+  {
+    "root": "C:\\CFH\\frontend\\src\\components\\user",
+    "ok": true,
+    "dry_run": false,
+    "converted": [
+      "C:/CFH/frontend/src/components/user/desktop.ini",
+      "C:/CFH/frontend/src/components/user/PointsHistory.jsx",
+      "C:/CFH/frontend/src/components/user/UserProfilePage.jsx"
+    ],
+    "skipped": []
+  },
+  {
+    "root": "C:\\CFH\\frontend\\src\\components\\valuation",
+    "ok": true,
+    "dry_run": false,
+    "converted": [
+      "C:/CFH/frontend/src/components/valuation/ARConditionScanner.test.tsx",
+      "C:/CFH/frontend/src/components/valuation/ARConditionScanner.tsx",
+      "C:/CFH/frontend/src/components/valuation/desktop.ini",
+      "C:/CFH/frontend/src/components/valuation/ValuationPortfolio.test.tsx",
+      "C:/CFH/frontend/src/components/valuation/ValuationPortfolio.tsx",
+      "C:/CFH/frontend/src/components/valuation/ValuationReport.test.tsx",
+      "C:/CFH/frontend/src/components/valuation/ValuationReport.tsx",
+      "C:/CFH/frontend/src/components/valuation/VehicleValuation.test.tsx",
+      "C:/CFH/frontend/src/components/valuation/VehicleValuation.tsx"
+    ],
+    "skipped": []
+  }
+]

--- a/reports/convert_batch_20251003_143644.json
+++ b/reports/convert_batch_20251003_143644.json
@@ -1,0 +1,950 @@
+[
+  {
+    "root": "C:\\CFH\\frontend\\src\\components\\admin",
+    "ok": true,
+    "dry_run": false,
+    "converted": [
+      "C:/CFH/frontend/src/components/admin/AdminAuctionOverview.jsx",
+      "C:/CFH/frontend/src/components/admin/AdminAuctionOverview.tsx",
+      "C:/CFH/frontend/src/components/admin/AdminCustomWidgetLibrary.jsx",
+      "C:/CFH/frontend/src/components/admin/AdminCustomWidgetLibrary.tsx",
+      "C:/CFH/frontend/src/components/admin/desktop.ini",
+      "C:/CFH/frontend/src/components/admin/LiveDashboardHealthWidget.jsx",
+      "C:/CFH/frontend/src/components/admin/LiveDashboardHealthWidget.tsx",
+      "C:/CFH/frontend/src/components/admin/analytics/AdminEngagementAnalytics.jsx",
+      "C:/CFH/frontend/src/components/admin/analytics/AdminRoleAnalytics.jsx",
+      "C:/CFH/frontend/src/components/admin/analytics/desktop.ini",
+      "C:/CFH/frontend/src/components/admin/arbitration/AdminArbitrationDashboard.css",
+      "C:/CFH/frontend/src/components/admin/arbitration/AdminArbitrationDashboard.jsx",
+      "C:/CFH/frontend/src/components/admin/arbitration/desktop.ini",
+      "C:/CFH/frontend/src/components/admin/auction/AdminAuctionOverview.jsx",
+      "C:/CFH/frontend/src/components/admin/auction/desktop.ini",
+      "C:/CFH/frontend/src/components/admin/badges/AdminBadgeAuditLog.css",
+      "C:/CFH/frontend/src/components/admin/badges/AdminBadgeAuditLog.jsx",
+      "C:/CFH/frontend/src/components/admin/badges/desktop.ini",
+      "C:/CFH/frontend/src/components/admin/compliance/AdminComplianceDashboard.jsx",
+      "C:/CFH/frontend/src/components/admin/compliance/desktop.ini",
+      "C:/CFH/frontend/src/components/admin/contract/AdminContractTemplates.jsx",
+      "C:/CFH/frontend/src/components/admin/contract/desktop.ini",
+      "C:/CFH/frontend/src/components/admin/dashboard/AdminDashboard.jsx",
+      "C:/CFH/frontend/src/components/admin/dashboard/AdminKPIWidget.jsx",
+      "C:/CFH/frontend/src/components/admin/dashboard/AdminSummaryPanel.jsx",
+      "C:/CFH/frontend/src/components/admin/dashboard/desktop.ini",
+      "C:/CFH/frontend/src/components/admin/disputes/AdminDisputeAnalytics.jsx"
+    ],
+    "skipped": [
+      "C:/CFH/frontend/src/components/admin/analytics",
+      "C:/CFH/frontend/src/components/admin/arbitration",
+      "C:/CFH/frontend/src/components/admin/auction",
+      "C:/CFH/frontend/src/components/admin/badges",
+      "C:/CFH/frontend/src/components/admin/compliance",
+      "C:/CFH/frontend/src/components/admin/contract",
+      "C:/CFH/frontend/src/components/admin/dashboard",
+      "C:/CFH/frontend/src/components/admin/disputes",
+      "C:/CFH/frontend/src/components/admin/escrow",
+      "C:/CFH/frontend/src/components/admin/export",
+      "C:/CFH/frontend/src/components/admin/finance",
+      "C:/CFH/frontend/src/components/admin/health",
+      "C:/CFH/frontend/src/components/admin/insights",
+      "C:/CFH/frontend/src/components/admin/layout",
+      "C:/CFH/frontend/src/components/admin/leaderboard",
+      "C:/CFH/frontend/src/components/admin/logins",
+      "C:/CFH/frontend/src/components/admin/loyalty",
+      "C:/CFH/frontend/src/components/admin/moderation",
+      "C:/CFH/frontend/src/components/admin/notifications",
+      "C:/CFH/frontend/src/components/admin/payments",
+      "C:/CFH/frontend/src/components/admin/reports",
+      "C:/CFH/frontend/src/components/admin/support",
+      "C:/CFH/frontend/src/components/admin/users"
+    ]
+  },
+  {
+    "root": "C:\\CFH\\frontend\\src\\components\\ai",
+    "ok": true,
+    "dry_run": false,
+    "converted": [
+      "C:/CFH/frontend/src/components/ai/AIBadgeOverlay.js",
+      "C:/CFH/frontend/src/components/ai/AIBadgeOverlay.ts",
+      "C:/CFH/frontend/src/components/ai/AIPredictorDashboard.jsx",
+      "C:/CFH/frontend/src/components/ai/AIPredictorDashboard.tsx",
+      "C:/CFH/frontend/src/components/ai/AIScorePanel.js",
+      "C:/CFH/frontend/src/components/ai/AIScorePanel.ts",
+      "C:/CFH/frontend/src/components/ai/BidConfidenceMeter.jsx",
+      "C:/CFH/frontend/src/components/ai/BidConfidenceMeter.tsx",
+      "C:/CFH/frontend/src/components/ai/BidStrategyAdvisor.jsx",
+      "C:/CFH/frontend/src/components/ai/BidStrategyAdvisor.tsx",
+      "C:/CFH/frontend/src/components/ai/desktop.ini",
+      "C:/CFH/frontend/src/components/ai/PredictiveComparison.jsx",
+      "C:/CFH/frontend/src/components/ai/PredictiveComparison.tsx",
+      "C:/CFH/frontend/src/components/ai/SmartInsightsWidget.js",
+      "C:/CFH/frontend/src/components/ai/SmartInsightsWidget.jsx",
+      "C:/CFH/frontend/src/components/ai/SmartInsightsWidget.ts",
+      "C:/CFH/frontend/src/components/ai/SmartInsightsWidget.tsx",
+      "C:/CFH/frontend/src/components/ai/TrustScoreViewer.jsx",
+      "C:/CFH/frontend/src/components/ai/TrustScoreViewer.tsx",
+      "C:/CFH/frontend/src/components/ai/ValuationAssistant.jsx",
+      "C:/CFH/frontend/src/components/ai/ValuationAssistant.tsx",
+      "C:/CFH/frontend/src/components/ai/ValuationLiveFeed.jsx",
+      "C:/CFH/frontend/src/components/ai/ValuationLiveFeed.tsx",
+      "C:/CFH/frontend/src/components/ai/bidding/CompetitiveBiddingInterface.jsx",
+      "C:/CFH/frontend/src/components/ai/bidding/desktop.ini"
+    ],
+    "skipped": [
+      "C:/CFH/frontend/src/components/ai/bidding"
+    ]
+  },
+  {
+    "root": "C:\\CFH\\frontend\\src\\components\\analytics",
+    "ok": true,
+    "dry_run": false,
+    "converted": [
+      "C:/CFH/frontend/src/components/analytics/AnalyticsDashboard.tsx",
+      "C:/CFH/frontend/src/components/analytics/BIIntegrationPanel.tsx",
+      "C:/CFH/frontend/src/components/analytics/ChartWidget.tsx",
+      "C:/CFH/frontend/src/components/analytics/DataTable.tsx",
+      "C:/CFH/frontend/src/components/analytics/desktop.ini",
+      "C:/CFH/frontend/src/components/analytics/FilterPanel.tsx",
+      "C:/CFH/frontend/src/components/analytics/NLPQueryInput.tsx",
+      "C:/CFH/frontend/src/components/analytics/PredictiveGraph.tsx",
+      "C:/CFH/frontend/src/components/analytics/QualityCheckComponent.tsx"
+    ],
+    "skipped": []
+  },
+  {
+    "root": "C:\\CFH\\frontend\\src\\components\\arbitrator",
+    "ok": true,
+    "dry_run": false,
+    "converted": [
+      "C:/CFH/frontend/src/components/arbitrator/ArbitratorAnalyticsPanel.jsx",
+      "C:/CFH/frontend/src/components/arbitrator/ArbitratorAnalyticsPanel.tsx",
+      "C:/CFH/frontend/src/components/arbitrator/ArbitratorDashboard.jsx",
+      "C:/CFH/frontend/src/components/arbitrator/ArbitratorDashboard.tsx",
+      "C:/CFH/frontend/src/components/arbitrator/desktop.ini"
+    ],
+    "skipped": []
+  },
+  {
+    "root": "C:\\CFH\\frontend\\src\\components\\auction",
+    "ok": true,
+    "dry_run": false,
+    "converted": [
+      "C:/CFH/frontend/src/components/auction/AuctionAccessibilityWrapper.jsx",
+      "C:/CFH/frontend/src/components/auction/AuctionAccessibilityWrapper.tsx",
+      "C:/CFH/frontend/src/components/auction/AuctionIntelligenceDashboard.jsx",
+      "C:/CFH/frontend/src/components/auction/AuctionIntelligenceDashboard.tsx",
+      "C:/CFH/frontend/src/components/auction/AuctionItemListing.tsx",
+      "C:/CFH/frontend/src/components/auction/AuctionLiveBidTracker.jsx",
+      "C:/CFH/frontend/src/components/auction/AuctionLiveBidTracker.tsx",
+      "C:/CFH/frontend/src/components/auction/AuctionManagement.tsx",
+      "C:/CFH/frontend/src/components/auction/AuctionPremiumInsightsPanel.jsx",
+      "C:/CFH/frontend/src/components/auction/AuctionPremiumInsightsPanel.tsx",
+      "C:/CFH/frontend/src/components/auction/AuctionSEOHead.jsx",
+      "C:/CFH/frontend/src/components/auction/AuctionSEOHead.tsx",
+      "C:/CFH/frontend/src/components/auction/desktop.ini",
+      "C:/CFH/frontend/src/components/auction/LiveAuctionStream.tsx",
+      "C:/CFH/frontend/src/components/auction/SellerBadgePanel.jsx",
+      "C:/CFH/frontend/src/components/auction/SellerBadgePanel.tsx",
+      "C:/CFH/frontend/src/components/auction/core/6 File.txt",
+      "C:/CFH/frontend/src/components/auction/core/AuctionHistoryTracker.jsx",
+      "C:/CFH/frontend/src/components/auction/core/AuctionListingForm.jsx",
+      "C:/CFH/frontend/src/components/auction/core/desktop.ini",
+      "C:/CFH/frontend/src/components/auction/core/here are the 10 files just was made.txt"
+    ],
+    "skipped": [
+      "C:/CFH/frontend/src/components/auction/core"
+    ]
+  },
+  {
+    "root": "C:\\CFH\\frontend\\src\\components\\auth",
+    "ok": true,
+    "dry_run": false,
+    "converted": [
+      "C:/CFH/frontend/src/components/auth/desktop.ini",
+      "C:/CFH/frontend/src/components/auth/Login.jsx",
+      "C:/CFH/frontend/src/components/auth/Login.tsx",
+      "C:/CFH/frontend/src/components/auth/LoginForm.jsx",
+      "C:/CFH/frontend/src/components/auth/LoginForm.tsx",
+      "C:/CFH/frontend/src/components/auth/ProtectedRoute.js",
+      "C:/CFH/frontend/src/components/auth/ProtectedRoute.ts",
+      "C:/CFH/frontend/src/components/auth/Register.jsx",
+      "C:/CFH/frontend/src/components/auth/Register.tsx",
+      "C:/CFH/frontend/src/components/auth/Unauthorized.jsx",
+      "C:/CFH/frontend/src/components/auth/Unauthorized.tsx"
+    ],
+    "skipped": []
+  },
+  {
+    "root": "C:\\CFH\\frontend\\src\\components\\blockchain",
+    "ok": true,
+    "dry_run": false,
+    "converted": [
+      "C:/CFH/frontend/src/components/blockchain/CryptoPaymentOption.jsx",
+      "C:/CFH/frontend/src/components/blockchain/CryptoPaymentOption.tsx",
+      "C:/CFH/frontend/src/components/blockchain/desktop.ini"
+    ],
+    "skipped": []
+  },
+  {
+    "root": "C:\\CFH\\frontend\\src\\components\\body-shop",
+    "ok": true,
+    "dry_run": false,
+    "converted": [
+      "C:/CFH/frontend/src/components/body-shop/AIDamageSummary.tsx",
+      "C:/CFH/frontend/src/components/body-shop/BodyShopDiscoveryPage.tsx",
+      "C:/CFH/frontend/src/components/body-shop/BodyShopProfileView.tsx",
+      "C:/CFH/frontend/src/components/body-shop/CompareShopsTable.tsx",
+      "C:/CFH/frontend/src/components/body-shop/desktop.ini",
+      "C:/CFH/frontend/src/components/body-shop/EstimateRequestForm.tsx",
+      "C:/CFH/frontend/src/components/body-shop/JobTrackingView.tsx",
+      "C:/CFH/frontend/src/components/body-shop/RepairJourneyShare.tsx",
+      "C:/CFH/frontend/src/components/body-shop/ShopOwnerDashboard.tsx",
+      "C:/CFH/frontend/src/components/body-shop/VirtualShopTour360.tsx"
+    ],
+    "skipped": []
+  },
+  {
+    "root": "C:\\CFH\\frontend\\src\\components\\buyer",
+    "ok": true,
+    "dry_run": false,
+    "converted": [
+      "C:/CFH/frontend/src/components/buyer/AdminSmartAlertEngine.jsx",
+      "C:/CFH/frontend/src/components/buyer/AdminSmartAlertEngine.tsx",
+      "C:/CFH/frontend/src/components/buyer/ARCarPreview.jsx",
+      "C:/CFH/frontend/src/components/buyer/ARCarPreview.tsx",
+      "C:/CFH/frontend/src/components/buyer/AuctionResultsViewer.jsx",
+      "C:/CFH/frontend/src/components/buyer/AuctionResultsViewer.tsx",
+      "C:/CFH/frontend/src/components/buyer/BidAssistantSimulator.jsx",
+      "C:/CFH/frontend/src/components/buyer/BidAssistantSimulator.tsx",
+      "C:/CFH/frontend/src/components/buyer/BuyerAISuggestionEngine.jsx",
+      "C:/CFH/frontend/src/components/buyer/BuyerAISuggestionEngine.tsx",
+      "C:/CFH/frontend/src/components/buyer/BuyerAnalyticsDashboard.jsx",
+      "C:/CFH/frontend/src/components/buyer/BuyerAnalyticsDashboard.tsx",
+      "C:/CFH/frontend/src/components/buyer/BuyerAuctionHistory.js",
+      "C:/CFH/frontend/src/components/buyer/BuyerAuctionHistory.jsx",
+      "C:/CFH/frontend/src/components/buyer/BuyerAuctionHistory.ts",
+      "C:/CFH/frontend/src/components/buyer/BuyerAuctionHistory.tsx",
+      "C:/CFH/frontend/src/components/buyer/BuyerBehaviorTracker.jsx",
+      "C:/CFH/frontend/src/components/buyer/BuyerBehaviorTracker.tsx",
+      "C:/CFH/frontend/src/components/buyer/BuyerBidHistory.jsx",
+      "C:/CFH/frontend/src/components/buyer/BuyerBidHistory.tsx",
+      "C:/CFH/frontend/src/components/buyer/BuyerBidModal.jsx",
+      "C:/CFH/frontend/src/components/buyer/BuyerBidModal.tsx",
+      "C:/CFH/frontend/src/components/buyer/BuyerCarCompare.css",
+      "C:/CFH/frontend/src/components/buyer/BuyerCarCompare.js",
+      "C:/CFH/frontend/src/components/buyer/BuyerCarCompare.ts",
+      "C:/CFH/frontend/src/components/buyer/BuyerCommunityForum.jsx",
+      "C:/CFH/frontend/src/components/buyer/BuyerCommunityForum.tsx",
+      "C:/CFH/frontend/src/components/buyer/BuyerContractPreviewer.jsx",
+      "C:/CFH/frontend/src/components/buyer/BuyerContractPreviewer.tsx",
+      "C:/CFH/frontend/src/components/buyer/BuyerDashboard.css",
+      "C:/CFH/frontend/src/components/buyer/BuyerDashboard.jsx",
+      "C:/CFH/frontend/src/components/buyer/BuyerDeliveryConfirmation.jsx",
+      "C:/CFH/frontend/src/components/buyer/BuyerEmailSettings.jsx",
+      "C:/CFH/frontend/src/components/buyer/BuyerEscrowStatus.jsx",
+      "C:/CFH/frontend/src/components/buyer/BuyerFinancingModal.jsx",
+      "C:/CFH/frontend/src/components/buyer/BuyerInspectionStatus.js",
+      "C:/CFH/frontend/src/components/buyer/BuyerLenderResults.jsx",
+      "C:/CFH/frontend/src/components/buyer/BuyerLoyaltyDashboard.jsx",
+      "C:/CFH/frontend/src/components/buyer/BuyerNotificationCenter.jsx",
+      "C:/CFH/frontend/src/components/buyer/BuyerOnboardingGuide.jsx",
+      "C:/CFH/frontend/src/components/buyer/BuyerPreferencesForm.css",
+      "C:/CFH/frontend/src/components/buyer/BuyerPreferencesForm.jsx",
+      "C:/CFH/frontend/src/components/buyer/BuyerProgressBar.jsx",
+      "C:/CFH/frontend/src/components/buyer/BuyerSearchPreferences.jsx",
+      "C:/CFH/frontend/src/components/buyer/desktop.ini",
+      "C:/CFH/frontend/src/components/buyer/FinancingOffer.js",
+      "C:/CFH/frontend/src/components/buyer/FinancingOptionsChart.jsx",
+      "C:/CFH/frontend/src/components/buyer/ai/AIPredictorDashboard.jsx",
+      "C:/CFH/frontend/src/components/buyer/ai/desktop.ini"
+    ],
+    "skipped": [
+      "C:/CFH/frontend/src/components/buyer/ai"
+    ]
+  },
+  {
+    "root": "C:\\CFH\\frontend\\src\\components\\chat",
+    "ok": true,
+    "dry_run": false,
+    "converted": [
+      "C:/CFH/frontend/src/components/chat/AuditTrail.jsx",
+      "C:/CFH/frontend/src/components/chat/ChatInterface.jsx",
+      "C:/CFH/frontend/src/components/chat/CollaborationChat.jsx",
+      "C:/CFH/frontend/src/components/chat/desktop.ini",
+      "C:/CFH/frontend/src/components/chat/MessageBubble.jsx"
+    ],
+    "skipped": []
+  },
+  {
+    "root": "C:\\CFH\\frontend\\src\\components\\common",
+    "ok": true,
+    "dry_run": false,
+    "converted": [
+      "C:/CFH/frontend/src/components/common/BlockchainSnapshotViewer.jsx",
+      "C:/CFH/frontend/src/components/common/Button.jsx",
+      "C:/CFH/frontend/src/components/common/Card.jsx",
+      "C:/CFH/frontend/src/components/common/ChatAttachmentPreviewer.jsx",
+      "C:/CFH/frontend/src/components/common/ChatAttachmentUploader.jsx",
+      "C:/CFH/frontend/src/components/common/CurrencyConverterWidget.jsx",
+      "C:/CFH/frontend/src/components/common/desktop.ini",
+      "C:/CFH/frontend/src/components/common/DocumentUploader.jsx",
+      "C:/CFH/frontend/src/components/common/ErrorBoundary.jsx",
+      "C:/CFH/frontend/src/components/common/ErrorBoundary.tsx",
+      "C:/CFH/frontend/src/components/common/FeedbackForm.jsx",
+      "C:/CFH/frontend/src/components/common/HeatmapChart.jsx",
+      "C:/CFH/frontend/src/components/common/ImageUploader.jsx",
+      "C:/CFH/frontend/src/components/common/Input.jsx",
+      "C:/CFH/frontend/src/components/common/LanguageSelector.jsx",
+      "C:/CFH/frontend/src/components/common/LoadingSpinner.jsx",
+      "C:/CFH/frontend/src/components/common/Messaging.jsx",
+      "C:/CFH/frontend/src/components/common/MobileUXEnhancer.jsx",
+      "C:/CFH/frontend/src/components/common/MultiLanguageSupport.jsx",
+      "C:/CFH/frontend/src/components/common/Navbar.css",
+      "C:/CFH/frontend/src/components/common/Navbar.jsx",
+      "C:/CFH/frontend/src/components/common/NavbarMobileToggle.jsx",
+      "C:/CFH/frontend/src/components/common/NotificationPreferences.jsx",
+      "C:/CFH/frontend/src/components/common/PDFPreviewModal.jsx",
+      "C:/CFH/frontend/src/components/common/PhotoProofUpload.jsx",
+      "C:/CFH/frontend/src/components/common/PredictiveGraph.jsx",
+      "C:/CFH/frontend/src/components/common/PremiumFeature.jsx",
+      "C:/CFH/frontend/src/components/common/ProtectedRoute.jsx",
+      "C:/CFH/frontend/src/components/common/SEOHead.jsx",
+      "C:/CFH/frontend/src/components/common/ToastManager.jsx",
+      "C:/CFH/frontend/src/components/common/ToastWrapper.jsx",
+      "C:/CFH/frontend/src/components/common/TrustAndAIExplainer.jsx",
+      "C:/CFH/frontend/src/components/common/UnifiedNotificationCenter.jsx",
+      "C:/CFH/frontend/src/components/common/UnreadNotificationBadge.jsx",
+      "C:/CFH/frontend/src/components/common/UserTrustBadges.jsx",
+      "C:/CFH/frontend/src/components/common/ValuationDisplay.jsx",
+      "C:/CFH/frontend/src/components/common/ValuationDisplay.tsx",
+      "C:/CFH/frontend/src/components/common/compliance/ComplianceConsentForm.jsx",
+      "C:/CFH/frontend/src/components/common/compliance/desktop.ini",
+      "C:/CFH/frontend/src/components/common/security/desktop.ini",
+      "C:/CFH/frontend/src/components/common/security/UserSecuritySettings.jsx"
+    ],
+    "skipped": [
+      "C:/CFH/frontend/src/components/common/compliance",
+      "C:/CFH/frontend/src/components/common/security"
+    ]
+  },
+  {
+    "root": "C:\\CFH\\frontend\\src\\components\\community",
+    "ok": true,
+    "dry_run": false,
+    "converted": [
+      "C:/CFH/frontend/src/components/community/CommunityForum.jsx",
+      "C:/CFH/frontend/src/components/community/CommunityLeaderboard.jsx",
+      "C:/CFH/frontend/src/components/community/desktop.ini"
+    ],
+    "skipped": []
+  },
+  {
+    "root": "C:\\CFH\\frontend\\src\\components\\contract",
+    "ok": true,
+    "dry_run": false,
+    "converted": [
+      "C:/CFH/frontend/src/components/contract/ContractPDFViewer.jsx",
+      "C:/CFH/frontend/src/components/contract/ContractSignaturePad.jsx",
+      "C:/CFH/frontend/src/components/contract/ContractSummary.jsx",
+      "C:/CFH/frontend/src/components/contract/ContractViewer.jsx",
+      "C:/CFH/frontend/src/components/contract/desktop.ini"
+    ],
+    "skipped": []
+  },
+  {
+    "root": "C:\\CFH\\frontend\\src\\components\\disputes",
+    "ok": true,
+    "dry_run": false,
+    "converted": [
+      "C:/CFH/frontend/src/components/disputes/desktop.ini",
+      "C:/CFH/frontend/src/components/disputes/DisputeAnalytics.jsx",
+      "C:/CFH/frontend/src/components/disputes/DisputeSimulator.jsx",
+      "C:/CFH/frontend/src/components/disputes/DisputeTimelineViewer.js",
+      "C:/CFH/frontend/src/components/disputes/DownloadCaseBundleButton.js",
+      "C:/CFH/frontend/src/components/disputes/DownloadDisputePDFButton.js",
+      "C:/CFH/frontend/src/components/disputes/JudgeBadgeRenderer.js",
+      "C:/CFH/frontend/src/components/disputes/JudgeLeaderboard.js",
+      "C:/CFH/frontend/src/components/disputes/New folder/desktop.ini",
+      "C:/CFH/frontend/src/components/disputes/styles/desktop.ini"
+    ],
+    "skipped": [
+      "C:/CFH/frontend/src/components/disputes/New folder",
+      "C:/CFH/frontend/src/components/disputes/styles"
+    ]
+  },
+  {
+    "root": "C:\\CFH\\frontend\\src\\components\\equity-hub",
+    "ok": true,
+    "dry_run": false,
+    "converted": [
+      "C:/CFH/frontend/src/components/equity-hub/desktop.ini",
+      "C:/CFH/frontend/src/components/equity-hub/EquityIntelligenceHub.jsx"
+    ],
+    "skipped": []
+  },
+  {
+    "root": "C:\\CFH\\frontend\\src\\components\\escrow",
+    "ok": true,
+    "dry_run": false,
+    "converted": [
+      "C:/CFH/frontend/src/components/escrow/desktop.ini",
+      "C:/CFH/frontend/src/components/escrow/EscrowAuditLogViewer.jsx",
+      "C:/CFH/frontend/src/components/escrow/EscrowConditionChecklist.jsx",
+      "C:/CFH/frontend/src/components/escrow/EscrowDashboard.jsx",
+      "C:/CFH/frontend/src/components/escrow/EscrowDocumentGallery.jsx",
+      "C:/CFH/frontend/src/components/escrow/EscrowDocumentUploader.jsx",
+      "C:/CFH/frontend/src/components/escrow/EscrowInfoPanel.js",
+      "C:/CFH/frontend/src/components/escrow/EscrowOfficerDashboard.jsx",
+      "C:/CFH/frontend/src/components/escrow/EscrowOfficerHook.js",
+      "C:/CFH/frontend/src/components/escrow/EscrowOfficerPremiumPanel.jsx",
+      "C:/CFH/frontend/src/components/escrow/EscrowPaymentManager.jsx",
+      "C:/CFH/frontend/src/components/escrow/EscrowPaymentManagerNeedsChecking.jsx",
+      "C:/CFH/frontend/src/components/escrow/EscrowRoleGuard.jsx",
+      "C:/CFH/frontend/src/components/escrow/EscrowSEOHead.jsx",
+      "C:/CFH/frontend/src/components/escrow/EscrowStatusNotifier.jsx",
+      "C:/CFH/frontend/src/components/escrow/EscrowStatusTracker.jsx",
+      "C:/CFH/frontend/src/components/escrow/EscrowStatusViewer.jsx",
+      "C:/CFH/frontend/src/components/escrow/EscrowSyncAdminPanel.jsx",
+      "C:/CFH/frontend/src/components/escrow/EscrowTransaction.tsx",
+      "C:/CFH/frontend/src/components/escrow/EscrowTransactionDetailModal.jsx",
+      "C:/CFH/frontend/src/components/escrow/EscrowTransactionPDFExporter.js",
+      "C:/CFH/frontend/src/components/escrow/EscrowTransactionSearch.jsx",
+      "C:/CFH/frontend/src/components/escrow/EscrowUserAnalyticsPanel.jsx"
+    ],
+    "skipped": []
+  },
+  {
+    "root": "C:\\CFH\\frontend\\src\\components\\finance",
+    "ok": true,
+    "dry_run": false,
+    "converted": [
+      "C:/CFH/frontend/src/components/finance/desktop.ini",
+      "C:/CFH/frontend/src/components/finance/FinanceRiskAssessment.jsx"
+    ],
+    "skipped": []
+  },
+  {
+    "root": "C:\\CFH\\frontend\\src\\components\\gamification",
+    "ok": true,
+    "dry_run": false,
+    "converted": [
+      "C:/CFH/frontend/src/components/gamification/AchievementPopup.jsx",
+      "C:/CFH/frontend/src/components/gamification/BadgeStorefront.jsx",
+      "C:/CFH/frontend/src/components/gamification/desktop.ini",
+      "C:/CFH/frontend/src/components/gamification/LeaderboardWidget.jsx"
+    ],
+    "skipped": []
+  },
+  {
+    "root": "C:\\CFH\\frontend\\src\\components\\guest",
+    "ok": true,
+    "dry_run": false,
+    "converted": [
+      "C:/CFH/frontend/src/components/guest/desktop.ini",
+      "C:/CFH/frontend/src/components/guest/GuestDashboard.jsx"
+    ],
+    "skipped": []
+  },
+  {
+    "root": "C:\\CFH\\frontend\\src\\components\\hauler",
+    "ok": true,
+    "dry_run": false,
+    "converted": [
+      "C:/CFH/frontend/src/components/hauler/BookingModal.jsx",
+      "C:/CFH/frontend/src/components/hauler/BookingModal.tsx",
+      "C:/CFH/frontend/src/components/hauler/CarTransportCoordination.jsx",
+      "C:/CFH/frontend/src/components/hauler/desktop.ini",
+      "C:/CFH/frontend/src/components/hauler/GeoStatusPanel.js",
+      "C:/CFH/frontend/src/components/hauler/HaulerAuctionDelivery.jsx",
+      "C:/CFH/frontend/src/components/hauler/HaulerCommunityBoard.jsx",
+      "C:/CFH/frontend/src/components/hauler/HaulerDashboard.css",
+      "C:/CFH/frontend/src/components/hauler/HaulerJobUploadForm.js",
+      "C:/CFH/frontend/src/components/hauler/HaulerLoyaltyDashboard.jsx",
+      "C:/CFH/frontend/src/components/hauler/HaulerReputationTracker.js",
+      "C:/CFH/frontend/src/components/hauler/hauler_job_details_page.tsx",
+      "C:/CFH/frontend/src/components/hauler/MissionCompletionLeaderboard.jsx",
+      "C:/CFH/frontend/src/components/hauler/PhotoEvidenceViewer.js",
+      "C:/CFH/frontend/src/components/hauler/RouteRiskAnalysis.jsx",
+      "C:/CFH/frontend/src/components/hauler/TransporterJobStatus.js",
+      "C:/CFH/frontend/src/components/hauler/TransporterLiveTracking.js",
+      "C:/CFH/frontend/src/components/hauler/__tests__/desktop.ini",
+      "C:/CFH/frontend/src/components/hauler/__tests__/hauler_job_details_page_test.ts",
+      "C:/CFH/frontend/src/components/hauler/__tests__/user_profile_routes_test.ts"
+    ],
+    "skipped": [
+      "C:/CFH/frontend/src/components/hauler/__tests__"
+    ]
+  },
+  {
+    "root": "C:\\CFH\\frontend\\src\\components\\inspections",
+    "ok": true,
+    "dry_run": false,
+    "converted": [
+      "C:/CFH/frontend/src/components/inspections/desktop.ini",
+      "C:/CFH/frontend/src/components/inspections/InspectionIndexPage.js",
+      "C:/CFH/frontend/src/components/inspections/InspectionReportList.js",
+      "C:/CFH/frontend/src/components/inspections/InspectionReportViewerPage.js",
+      "C:/CFH/frontend/src/components/inspections/InspectionSearchBar.js",
+      "C:/CFH/frontend/src/components/inspections/PhotoUpload.tsx",
+      "C:/CFH/frontend/src/components/inspections/VRInspection.js"
+    ],
+    "skipped": []
+  },
+  {
+    "root": "C:\\CFH\\frontend\\src\\components\\insurance",
+    "ok": true,
+    "dry_run": false,
+    "converted": [
+      "C:/CFH/frontend/src/components/insurance/ClaimsProcessor.jsx",
+      "C:/CFH/frontend/src/components/insurance/desktop.ini",
+      "C:/CFH/frontend/src/components/insurance/InsuranceAIModelPerformance.jsx",
+      "C:/CFH/frontend/src/components/insurance/InsuranceClaimsAnalytics.jsx",
+      "C:/CFH/frontend/src/components/insurance/InsuranceClaimsProcessor.jsx",
+      "C:/CFH/frontend/src/components/insurance/InsuranceComparison.js",
+      "C:/CFH/frontend/src/components/insurance/InsuranceDashboard.js",
+      "C:/CFH/frontend/src/components/insurance/InsuranceOfficerDashboard.jsx",
+      "C:/CFH/frontend/src/components/insurance/InsurancePolicyManager.jsx",
+      "C:/CFH/frontend/src/components/insurance/InsuranceRoleGuard.jsx",
+      "C:/CFH/frontend/src/components/insurance/InsuranceSEOHead.jsx",
+      "C:/CFH/frontend/src/components/insurance/InsuranceUnderwritingChecklist.jsx",
+      "C:/CFH/frontend/src/components/insurance/InsurerInsightsChart.jsx",
+      "C:/CFH/frontend/src/components/insurance/PolicyReviewQueue.js",
+      "C:/CFH/frontend/src/components/insurance/QuoteSubmissionForm.js"
+    ],
+    "skipped": []
+  },
+  {
+    "root": "C:\\CFH\\frontend\\src\\components\\internal",
+    "ok": true,
+    "dry_run": false,
+    "converted": [
+      "C:/CFH/frontend/src/components/internal/desktop.ini",
+      "C:/CFH/frontend/src/components/internal/TestRunnerDashboard.jsx"
+    ],
+    "skipped": []
+  },
+  {
+    "root": "C:\\CFH\\frontend\\src\\components\\judge",
+    "ok": true,
+    "dry_run": false,
+    "converted": [
+      "C:/CFH/frontend/src/components/judge/ArbitrationDashboard.js",
+      "C:/CFH/frontend/src/components/judge/desktop.ini",
+      "C:/CFH/frontend/src/components/judge/DisputeAnalyticsPanel.jsx",
+      "C:/CFH/frontend/src/components/judge/JudgeDashboard.js",
+      "C:/CFH/frontend/src/components/judge/JudgePanelControls.jsx",
+      "C:/CFH/frontend/src/components/judge/SmartVerdictHint.jsx",
+      "C:/CFH/frontend/src/components/judge/components/desktop.ini",
+      "C:/CFH/frontend/src/components/judge/components/DisputeCard.js"
+    ],
+    "skipped": [
+      "C:/CFH/frontend/src/components/judge/components"
+    ]
+  },
+  {
+    "root": "C:\\CFH\\frontend\\src\\components\\lender",
+    "ok": true,
+    "dry_run": false,
+    "converted": [
+      "C:/CFH/frontend/src/components/lender/BidDetailViewer.js",
+      "C:/CFH/frontend/src/components/lender/contractReviewController.js",
+      "C:/CFH/frontend/src/components/lender/desktop.ini",
+      "C:/CFH/frontend/src/components/lender/FinancingOffer.js",
+      "C:/CFH/frontend/src/components/lender/LenderAnalyticsDashboard.js",
+      "C:/CFH/frontend/src/components/lender/LenderBidDetailCard.js",
+      "C:/CFH/frontend/src/components/lender/LenderBiddingDashboard.css",
+      "C:/CFH/frontend/src/components/lender/LenderBiddingDashboard.js",
+      "C:/CFH/frontend/src/components/lender/LenderContractReview.js",
+      "C:/CFH/frontend/src/components/lender/LenderContractSummary.js",
+      "C:/CFH/frontend/src/components/lender/LenderDashboard.js",
+      "C:/CFH/frontend/src/components/lender/LenderDashboard.jsx",
+      "C:/CFH/frontend/src/components/lender/LenderExportCenter.js",
+      "C:/CFH/frontend/src/components/lender/LenderExportPanel.js",
+      "C:/CFH/frontend/src/components/lender/LenderExportPanel.jsx",
+      "C:/CFH/frontend/src/components/lender/LenderInsightsPanel.js",
+      "C:/CFH/frontend/src/components/lender/LenderLoyaltyDashboard.jsx",
+      "C:/CFH/frontend/src/components/lender/LenderMatchListView.js",
+      "C:/CFH/frontend/src/components/lender/LenderMatchPreviewCard.js",
+      "C:/CFH/frontend/src/components/lender/LenderOnboardingForm.js",
+      "C:/CFH/frontend/src/components/lender/LenderPreApprovalDashboard.js",
+      "C:/CFH/frontend/src/components/lender/LenderProfilePage.js",
+      "C:/CFH/frontend/src/components/lender/lenderReputationController.js",
+      "C:/CFH/frontend/src/components/lender/LenderReputationSummary.js",
+      "C:/CFH/frontend/src/components/lender/LenderReputationTracker.js",
+      "C:/CFH/frontend/src/components/lender/LenderReviewDashboard.js",
+      "C:/CFH/frontend/src/components/lender/LenderTermsHistoryViewer.jsx",
+      "C:/CFH/frontend/src/components/lender/LoanComparison.css",
+      "C:/CFH/frontend/src/components/lender/LoanComparison.js"
+    ],
+    "skipped": []
+  },
+  {
+    "root": "C:\\CFH\\frontend\\src\\components\\maas",
+    "ok": true,
+    "dry_run": false,
+    "converted": [
+      "C:/CFH/frontend/src/components/maas/BulkTitleTransfer.jsx",
+      "C:/CFH/frontend/src/components/maas/desktop.ini",
+      "C:/CFH/frontend/src/components/maas/MaaSIntegration.jsx"
+    ],
+    "skipped": []
+  },
+  {
+    "root": "C:\\CFH\\frontend\\src\\components\\marketplace",
+    "ok": true,
+    "dry_run": false,
+    "converted": [
+      "C:/CFH/frontend/src/components/marketplace/ActivityOverview.jsx",
+      "C:/CFH/frontend/src/components/marketplace/BadgeDisplayPanel.jsx",
+      "C:/CFH/frontend/src/components/marketplace/BestFinancingDealCard.jsx",
+      "C:/CFH/frontend/src/components/marketplace/desktop.ini",
+      "C:/CFH/frontend/src/components/marketplace/HaulerSummaryCard.jsx",
+      "C:/CFH/frontend/src/components/marketplace/MarketplaceComponent.tsx",
+      "C:/CFH/frontend/src/components/marketplace/MarketplaceInsightsDashboard.jsx"
+    ],
+    "skipped": []
+  },
+  {
+    "root": "C:\\CFH\\frontend\\src\\components\\mechanic",
+    "ok": true,
+    "dry_run": false,
+    "converted": [
+      "C:/CFH/frontend/src/components/mechanic/AIDiagnosticsAssistant.jsx",
+      "C:/CFH/frontend/src/components/mechanic/desktop.ini",
+      "C:/CFH/frontend/src/components/mechanic/EscrowStatusSync.jsx",
+      "C:/CFH/frontend/src/components/mechanic/HaulerCollaboration.jsx",
+      "C:/CFH/frontend/src/components/mechanic/InspectionForm.js",
+      "C:/CFH/frontend/src/components/mechanic/InspectionPhotoPreviewer.jsx",
+      "C:/CFH/frontend/src/components/mechanic/InspectionReportPanel.jsx",
+      "C:/CFH/frontend/src/components/mechanic/InspectionReportViewer.js",
+      "C:/CFH/frontend/src/components/mechanic/LiveInspectionTaskFeed.jsx",
+      "C:/CFH/frontend/src/components/mechanic/MechanicBadgeConfettiPanel.jsx",
+      "C:/CFH/frontend/src/components/mechanic/MechanicBadgeDisplayPanel.jsx",
+      "C:/CFH/frontend/src/components/mechanic/MechanicBadgeImpactTracker.jsx",
+      "C:/CFH/frontend/src/components/mechanic/MechanicBadgeLeaderboard.jsx",
+      "C:/CFH/frontend/src/components/mechanic/MechanicBadgeProgressTracker.jsx",
+      "C:/CFH/frontend/src/components/mechanic/MechanicDashboard.jsx",
+      "C:/CFH/frontend/src/components/mechanic/MechanicInspectionDetail.js",
+      "C:/CFH/frontend/src/components/mechanic/MechanicInspectionForm.jsx",
+      "C:/CFH/frontend/src/components/mechanic/MechanicJobStatusBadge.jsx",
+      "C:/CFH/frontend/src/components/mechanic/MechanicMilestoneTracker.jsx",
+      "C:/CFH/frontend/src/components/mechanic/MechanicProgressReviewBoard.jsx",
+      "C:/CFH/frontend/src/components/mechanic/MechanicRepairHistoryTimeline.jsx",
+      "C:/CFH/frontend/src/components/mechanic/MechanicReportDashboard.jsx",
+      "C:/CFH/frontend/src/components/mechanic/MechanicReviewPanel.jsx",
+      "C:/CFH/frontend/src/components/mechanic/MechanicRewardConfetti.jsx",
+      "C:/CFH/frontend/src/components/mechanic/MechanicShiftPlanner.jsx",
+      "C:/CFH/frontend/src/components/mechanic/MechanicTaskHistoryTable.jsx",
+      "C:/CFH/frontend/src/components/mechanic/MechanicTaskOutcomeReporter.jsx",
+      "C:/CFH/frontend/src/components/mechanic/MechanicTaskReporter.jsx",
+      "C:/CFH/frontend/src/components/mechanic/MechanicTimelineCelebration.jsx",
+      "C:/CFH/frontend/src/components/mechanic/MechanicVRPhotoUploader.jsx",
+      "C:/CFH/frontend/src/components/mechanic/MechanicVRPreviewViewer.jsx",
+      "C:/CFH/frontend/src/components/mechanic/PremiumBadgeHintCard.jsx",
+      "C:/CFH/frontend/src/components/mechanic/RepairScheduler.jsx",
+      "C:/CFH/frontend/src/components/mechanic/SharedReportViewer.jsx",
+      "C:/CFH/frontend/src/components/mechanic/TaskCompletionButton.jsx",
+      "C:/CFH/frontend/src/components/mechanic/VehicleHealthTrendCharts.jsx",
+      "C:/CFH/frontend/src/components/mechanic/VehicleInspectionModule.jsx",
+      "C:/CFH/frontend/src/components/mechanic/VINDecoder.jsx",
+      "C:/CFH/frontend/src/components/mechanic/VRInspectionViewer.jsx"
+    ],
+    "skipped": []
+  },
+  {
+    "root": "C:\\CFH\\frontend\\src\\components\\mobile",
+    "ok": true,
+    "dry_run": false,
+    "converted": [
+      "C:/CFH/frontend/src/components/mobile/desktop.ini",
+      "C:/CFH/frontend/src/components/mobile/MobileAnalytics.jsx",
+      "C:/CFH/frontend/src/components/mobile/MobileAuctionView.jsx"
+    ],
+    "skipped": []
+  },
+  {
+    "root": "C:\\CFH\\frontend\\src\\components\\mock",
+    "ok": true,
+    "dry_run": false,
+    "converted": [
+      "C:/CFH/frontend/src/components/mock/desktop.ini",
+      "C:/CFH/frontend/src/components/mock/MockComponent.jsx"
+    ],
+    "skipped": []
+  },
+  {
+    "root": "C:\\CFH\\frontend\\src\\components\\needsHome",
+    "ok": true,
+    "dry_run": false,
+    "converted": [
+      "C:/CFH/frontend/src/components/needsHome/ARExperience.js",
+      "C:/CFH/frontend/src/components/needsHome/AutomationAgent.js",
+      "C:/CFH/frontend/src/components/needsHome/BadgeDisplay.js",
+      "C:/CFH/frontend/src/components/needsHome/BulkUpload.css",
+      "C:/CFH/frontend/src/components/needsHome/BulkUpload.js",
+      "C:/CFH/frontend/src/components/needsHome/Button.js",
+      "C:/CFH/frontend/src/components/needsHome/CommunityDashboard.css",
+      "C:/CFH/frontend/src/components/needsHome/CommunityDashboard.js",
+      "C:/CFH/frontend/src/components/needsHome/CommunityHub.js",
+      "C:/CFH/frontend/src/components/needsHome/CommunityHubEnhanced.js",
+      "C:/CFH/frontend/src/components/needsHome/CommunityModeratorDashboard.js",
+      "C:/CFH/frontend/src/components/needsHome/ComplianceReviewerDashboard.js",
+      "C:/CFH/frontend/src/components/needsHome/CrossBorderFinancing.js",
+      "C:/CFH/frontend/src/components/needsHome/desktop.ini",
+      "C:/CFH/frontend/src/components/needsHome/DynamicPricing.js",
+      "C:/CFH/frontend/src/components/needsHome/FinancingCalculator.css",
+      "C:/CFH/frontend/src/components/needsHome/FinancingCalculator.js",
+      "C:/CFH/frontend/src/components/needsHome/Forum.css",
+      "C:/CFH/frontend/src/components/needsHome/FraudDetection.js",
+      "C:/CFH/frontend/src/components/needsHome/integrationReportValidation.js",
+      "C:/CFH/frontend/src/components/needsHome/Leaderboard.css",
+      "C:/CFH/frontend/src/components/needsHome/Leaderboard.js",
+      "C:/CFH/frontend/src/components/needsHome/LeaveReview.css",
+      "C:/CFH/frontend/src/components/needsHome/LeaveReview.js",
+      "C:/CFH/frontend/src/components/needsHome/LoadingSpinner.js",
+      "C:/CFH/frontend/src/components/needsHome/LoanComparison.js",
+      "C:/CFH/frontend/src/components/needsHome/LoyaltyQuests.js",
+      "C:/CFH/frontend/src/components/needsHome/MarketplaceInsights.js",
+      "C:/CFH/frontend/src/components/needsHome/Messaging.css",
+      "C:/CFH/frontend/src/components/needsHome/Messaging.js",
+      "C:/CFH/frontend/src/components/needsHome/Navbar.js",
+      "C:/CFH/frontend/src/components/needsHome/NotificationCenter.css",
+      "C:/CFH/frontend/src/components/needsHome/NotificationCenter.js",
+      "C:/CFH/frontend/src/components/needsHome/PaymentForm.js",
+      "C:/CFH/frontend/src/components/needsHome/ProtectedRoute.js",
+      "C:/CFH/frontend/src/components/needsHome/ReferralAnalytics.js",
+      "C:/CFH/frontend/src/components/needsHome/Register.js",
+      "C:/CFH/frontend/src/components/needsHome/RegisterForm.js",
+      "C:/CFH/frontend/src/components/needsHome/ReputationBadgeTier.css",
+      "C:/CFH/frontend/src/components/needsHome/ReputationBadgeTier.js",
+      "C:/CFH/frontend/src/components/needsHome/RoleActivityCharts.css",
+      "C:/CFH/frontend/src/components/needsHome/RoleActivityCharts.js",
+      "C:/CFH/frontend/src/components/needsHome/RoleSwitchWrapper.js",
+      "C:/CFH/frontend/src/components/needsHome/SellerCreateListing.js",
+      "C:/CFH/frontend/src/components/needsHome/SellerDashboard.js",
+      "C:/CFH/frontend/src/components/needsHome/SmartRecommendations.css",
+      "C:/CFH/frontend/src/components/needsHome/SmartRecommendations.js",
+      "C:/CFH/frontend/src/components/needsHome/SupportCenter.js",
+      "C:/CFH/frontend/src/components/needsHome/TradeInForm.js",
+      "C:/CFH/frontend/src/components/needsHome/useAuth.js"
+    ],
+    "skipped": []
+  },
+  {
+    "root": "C:\\CFH\\frontend\\src\\components\\notifications",
+    "ok": true,
+    "dry_run": false,
+    "converted": [
+      "C:/CFH/frontend/src/components/notifications/AdminEmailNotifications.jsx",
+      "C:/CFH/frontend/src/components/notifications/desktop.ini",
+      "C:/CFH/frontend/src/components/notifications/NotificationCenter.jsx",
+      "C:/CFH/frontend/src/components/notifications/NotificationsComponent.tsx",
+      "C:/CFH/frontend/src/components/notifications/UnreadNotificationBadge.jsx"
+    ],
+    "skipped": []
+  },
+  {
+    "root": "C:\\CFH\\frontend\\src\\components\\officer",
+    "ok": true,
+    "dry_run": false,
+    "converted": [
+      "C:/CFH/frontend/src/components/officer/desktop.ini",
+      "C:/CFH/frontend/src/components/officer/DisputeRadarWidget.jsx"
+    ],
+    "skipped": []
+  },
+  {
+    "root": "C:\\CFH\\frontend\\src\\components\\onboarding",
+    "ok": true,
+    "dry_run": false,
+    "converted": [
+      "C:/CFH/frontend/src/components/onboarding/desktop.ini",
+      "C:/CFH/frontend/src/components/onboarding/FinancierOnboarding.js",
+      "C:/CFH/frontend/src/components/onboarding/OnboardingGuide.js",
+      "C:/CFH/frontend/src/components/onboarding/OnboardingTrigger.jsx",
+      "C:/CFH/frontend/src/components/onboarding/OnboardingWizard.jsx"
+    ],
+    "skipped": []
+  },
+  {
+    "root": "C:\\CFH\\frontend\\src\\components\\partner",
+    "ok": true,
+    "dry_run": false,
+    "converted": [
+      "C:/CFH/frontend/src/components/partner/desktop.ini",
+      "C:/CFH/frontend/src/components/partner/PartnerPortal.jsx"
+    ],
+    "skipped": []
+  },
+  {
+    "root": "C:\\CFH\\frontend\\src\\components\\premium",
+    "ok": true,
+    "dry_run": false,
+    "converted": [
+      "C:/CFH/frontend/src/components/premium/BadgeDisplay.jsx",
+      "C:/CFH/frontend/src/components/premium/desktop.ini",
+      "C:/CFH/frontend/src/components/premium/LeaderboardDisplay.jsx",
+      "C:/CFH/frontend/src/components/premium/LiveStreamViewer.jsx",
+      "C:/CFH/frontend/src/components/premium/PredictiveAssistant.jsx",
+      "C:/CFH/frontend/src/components/premium/PremiumDashboard.jsx",
+      "C:/CFH/frontend/src/components/premium/PricingInsights.jsx",
+      "C:/CFH/frontend/src/components/premium/RecommendedAuctions.jsx",
+      "C:/CFH/frontend/src/components/premium/SupportChatWidget.jsx",
+      "C:/CFH/frontend/src/components/premium/SustainabilityMetrics.jsx",
+      "C:/CFH/frontend/src/components/premium/VRTourLauncher.jsx"
+    ],
+    "skipped": []
+  },
+  {
+    "root": "C:\\CFH\\frontend\\src\\components\\recommendations",
+    "ok": true,
+    "dry_run": false,
+    "converted": [
+      "C:/CFH/frontend/src/components/recommendations/AdvancedSmartRecommendations.js",
+      "C:/CFH/frontend/src/components/recommendations/AIInsights.js",
+      "C:/CFH/frontend/src/components/recommendations/AIRecommendations.css",
+      "C:/CFH/frontend/src/components/recommendations/AIRecommendations.js",
+      "C:/CFH/frontend/src/components/recommendations/desktop.ini",
+      "C:/CFH/frontend/src/components/recommendations/loanRecommendationController.js",
+      "C:/CFH/frontend/src/components/recommendations/SustainabilityScoring.js"
+    ],
+    "skipped": []
+  },
+  {
+    "root": "C:\\CFH\\frontend\\src\\components\\seller",
+    "ok": true,
+    "dry_run": false,
+    "converted": [
+      "C:/CFH/frontend/src/components/seller/AISuggestionEngine.js",
+      "C:/CFH/frontend/src/components/seller/CreateListingForm.js",
+      "C:/CFH/frontend/src/components/seller/desktop.ini",
+      "C:/CFH/frontend/src/components/seller/SellerAchievementTracker.jsx",
+      "C:/CFH/frontend/src/components/seller/SellerActionPanel.jsx",
+      "C:/CFH/frontend/src/components/seller/SellerActivityInsights.jsx",
+      "C:/CFH/frontend/src/components/seller/SellerActivityTimeline.jsx",
+      "C:/CFH/frontend/src/components/seller/SellerAnalyticsChart.jsx",
+      "C:/CFH/frontend/src/components/seller/SellerAuctionForm.jsx",
+      "C:/CFH/frontend/src/components/seller/SellerAuctionStarter.jsx",
+      "C:/CFH/frontend/src/components/seller/SellerAuctionStatus.jsx",
+      "C:/CFH/frontend/src/components/seller/SellerBadgesPage.jsx",
+      "C:/CFH/frontend/src/components/seller/SellerContractManager.jsx",
+      "C:/CFH/frontend/src/components/seller/SellerCreateListing.jsx",
+      "C:/CFH/frontend/src/components/seller/SellerCustomerTestimonials.jsx",
+      "C:/CFH/frontend/src/components/seller/SellerDashboard.css",
+      "C:/CFH/frontend/src/components/seller/SellerDashboard.jsx",
+      "C:/CFH/frontend/src/components/seller/SellerDeepAnalytics.jsx",
+      "C:/CFH/frontend/src/components/seller/SellerDisputeCenter.jsx",
+      "C:/CFH/frontend/src/components/seller/SellerDocVault.jsx",
+      "C:/CFH/frontend/src/components/seller/SellerEditListing.jsx",
+      "C:/CFH/frontend/src/components/seller/SellerEmailSettings.jsx",
+      "C:/CFH/frontend/src/components/seller/SellerEngagementLeaderboard.jsx",
+      "C:/CFH/frontend/src/components/seller/SellerEscrowStatus.jsx",
+      "C:/CFH/frontend/src/components/seller/SellerExperienceLevel.jsx",
+      "C:/CFH/frontend/src/components/seller/SellerExportPanel.jsx",
+      "C:/CFH/frontend/src/components/seller/SellerGalleryManager.jsx",
+      "C:/CFH/frontend/src/components/seller/SellerInventoryList.jsx",
+      "C:/CFH/frontend/src/components/seller/SellerKPIWidget.jsx",
+      "C:/CFH/frontend/src/components/seller/SellerListingEdit.jsx",
+      "C:/CFH/frontend/src/components/seller/SellerListingGallery.jsx",
+      "C:/CFH/frontend/src/components/seller/SellerManageListings.jsx",
+      "C:/CFH/frontend/src/components/seller/SellerMarketTrendInsights.jsx",
+      "C:/CFH/frontend/src/components/seller/SellerMilestoneCelebrator.jsx",
+      "C:/CFH/frontend/src/components/seller/SellerMissionCenter.jsx",
+      "C:/CFH/frontend/src/components/seller/SellerNotificationCenter.jsx",
+      "C:/CFH/frontend/src/components/seller/SellerNotifications.jsx",
+      "C:/CFH/frontend/src/components/seller/SellerOfferTracker.jsx",
+      "C:/CFH/frontend/src/components/seller/SellerOnboardingGuide.jsx",
+      "C:/CFH/frontend/src/components/seller/SellerPerformanceComparison.jsx",
+      "C:/CFH/frontend/src/components/seller/SellerPricingTool.css",
+      "C:/CFH/frontend/src/components/seller/SellerPricingTool.js",
+      "C:/CFH/frontend/src/components/seller/SellerProfileCard.jsx",
+      "C:/CFH/frontend/src/components/seller/SellerReputationDashboard.jsx",
+      "C:/CFH/frontend/src/components/seller/SellerReviewSummary.jsx",
+      "C:/CFH/frontend/src/components/seller/SellerRewardsBadgeDisplay.jsx",
+      "C:/CFH/frontend/src/components/seller/SellerSalesAnalytics.jsx",
+      "C:/CFH/frontend/src/components/seller/SellerSalesFunnelOverview.jsx",
+      "C:/CFH/frontend/src/components/seller/SellerSmartBadgeSystem.jsx",
+      "C:/CFH/frontend/src/components/seller/SellerSuccessTips.jsx"
+    ],
+    "skipped": []
+  },
+  {
+    "root": "C:\\CFH\\frontend\\src\\components\\storage",
+    "ok": true,
+    "dry_run": false,
+    "converted": [
+      "C:/CFH/frontend/src/components/storage/desktop.ini",
+      "C:/CFH/frontend/src/components/storage/StorageARNavigationApp.jsx",
+      "C:/CFH/frontend/src/components/storage/StorageAssignmentForm.jsx",
+      "C:/CFH/frontend/src/components/storage/StorageHostDashboard.js",
+      "C:/CFH/frontend/src/components/storage/StorageInventoryTracker.jsx"
+    ],
+    "skipped": []
+  },
+  {
+    "root": "C:\\CFH\\frontend\\src\\components\\support",
+    "ok": true,
+    "dry_run": false,
+    "converted": [
+      "C:/CFH/frontend/src/components/support/desktop.ini",
+      "C:/CFH/frontend/src/components/support/File SellerAuctionStatus.jsx.txt",
+      "C:/CFH/frontend/src/components/support/SupportChatWidget.jsx",
+      "C:/CFH/frontend/src/components/support/SupportDashboard.jsx",
+      "C:/CFH/frontend/src/components/support/SupportTicketAnalytics.jsx",
+      "C:/CFH/frontend/src/components/support/SupportTicketForm.jsx",
+      "C:/CFH/frontend/src/components/support/SupportTicketFormInLineFromGrok.jsx"
+    ],
+    "skipped": []
+  },
+  {
+    "root": "C:\\CFH\\frontend\\src\\components\\tinting",
+    "ok": true,
+    "dry_run": false,
+    "converted": [
+      "C:/CFH/frontend/src/components/tinting/desktop.ini",
+      "C:/CFH/frontend/src/components/tinting/TintingServiceDiscovery.tsx",
+      "C:/CFH/frontend/src/components/tinting/WindowTintingScheduler.tsx"
+    ],
+    "skipped": []
+  },
+  {
+    "root": "C:\\CFH\\frontend\\src\\components\\title",
+    "ok": true,
+    "dry_run": false,
+    "converted": [
+      "C:/CFH/frontend/src/components/title/BulkTitleTransfer.jsx",
+      "C:/CFH/frontend/src/components/title/desktop.ini",
+      "C:/CFH/frontend/src/components/title/TitleAgentDashboard.js",
+      "C:/CFH/frontend/src/components/title/TitleTransferQueue.js",
+      "C:/CFH/frontend/src/components/title/TitleVerificationForm.js"
+    ],
+    "skipped": []
+  },
+  {
+    "root": "C:\\CFH\\frontend\\src\\components\\user",
+    "ok": true,
+    "dry_run": false,
+    "converted": [
+      "C:/CFH/frontend/src/components/user/desktop.ini",
+      "C:/CFH/frontend/src/components/user/PointsHistory.jsx",
+      "C:/CFH/frontend/src/components/user/UserProfilePage.jsx"
+    ],
+    "skipped": []
+  },
+  {
+    "root": "C:\\CFH\\frontend\\src\\components\\valuation",
+    "ok": true,
+    "dry_run": false,
+    "converted": [
+      "C:/CFH/frontend/src/components/valuation/ARConditionScanner.test.tsx",
+      "C:/CFH/frontend/src/components/valuation/ARConditionScanner.tsx",
+      "C:/CFH/frontend/src/components/valuation/desktop.ini",
+      "C:/CFH/frontend/src/components/valuation/ValuationPortfolio.test.tsx",
+      "C:/CFH/frontend/src/components/valuation/ValuationPortfolio.tsx",
+      "C:/CFH/frontend/src/components/valuation/ValuationReport.test.tsx",
+      "C:/CFH/frontend/src/components/valuation/ValuationReport.tsx",
+      "C:/CFH/frontend/src/components/valuation/VehicleValuation.test.tsx",
+      "C:/CFH/frontend/src/components/valuation/VehicleValuation.tsx"
+    ],
+    "skipped": []
+  }
+]

--- a/reports/reviews_20251003_154759.json
+++ b/reports/reviews_20251003_154759.json
@@ -1,0 +1,282 @@
+{
+  "root": "C:\\CFH\\frontend\\src\\components\\needsHome",
+  "generated_at": 1759531679,
+  "count": 25,
+  "items": [
+    {
+      "src": "C:\\CFH\\frontend\\src\\components\\needsHome\\ARExperience.js",
+      "suggested_moves": [
+        {
+          "dest": "C:\\CFH\\frontend\\src\\components\\seller\\ARExperience.js",
+          "confidence": 0.7,
+          "reason": "Matched keyword rule \"\\bseller\\b|\\blisting\\b|\\binventory\\b\" \u2192 \"seller\""
+        }
+      ],
+      "doc_mirror": "C:\\CFH\\docs\\frontend\\src\\components\\needsHome\\ARExperience.md"
+    },
+    {
+      "src": "C:\\CFH\\frontend\\src\\components\\needsHome\\AutomationAgent.js",
+      "suggested_moves": [
+        {
+          "dest": "C:\\CFH\\frontend\\src\\components\\common\\AutomationAgent.js",
+          "confidence": 0.3,
+          "reason": "Default to common (no strong signals)."
+        }
+      ],
+      "doc_mirror": "C:\\CFH\\docs\\frontend\\src\\components\\needsHome\\AutomationAgent.md"
+    },
+    {
+      "src": "C:\\CFH\\frontend\\src\\components\\needsHome\\BadgeDisplay.js",
+      "suggested_moves": [
+        {
+          "dest": "C:\\CFH\\frontend\\src\\components\\common\\BadgeDisplay.js",
+          "confidence": 0.3,
+          "reason": "Default to common (no strong signals)."
+        }
+      ],
+      "doc_mirror": "C:\\CFH\\docs\\frontend\\src\\components\\needsHome\\BadgeDisplay.md"
+    },
+    {
+      "src": "C:\\CFH\\frontend\\src\\components\\needsHome\\BulkUpload.js",
+      "suggested_moves": [
+        {
+          "dest": "C:\\CFH\\frontend\\src\\components\\chat\\BulkUpload.js",
+          "confidence": 0.7,
+          "reason": "Matched keyword rule \"\\bchat\\b|\\bmessage\\b|\\bthread\\b\" \u2192 \"chat\""
+        }
+      ],
+      "doc_mirror": "C:\\CFH\\docs\\frontend\\src\\components\\needsHome\\BulkUpload.md"
+    },
+    {
+      "src": "C:\\CFH\\frontend\\src\\components\\needsHome\\Button.js",
+      "suggested_moves": [
+        {
+          "dest": "C:\\CFH\\frontend\\src\\components\\common\\Button.js",
+          "confidence": 0.3,
+          "reason": "Default to common (no strong signals)."
+        }
+      ],
+      "doc_mirror": "C:\\CFH\\docs\\frontend\\src\\components\\needsHome\\Button.md"
+    },
+    {
+      "src": "C:\\CFH\\frontend\\src\\components\\needsHome\\CommunityDashboard.js",
+      "suggested_moves": [
+        {
+          "dest": "C:\\CFH\\frontend\\src\\components\\auth\\CommunityDashboard.js",
+          "confidence": 0.7,
+          "reason": "Matched keyword rule \"\\buser\\b|\\bauth\\b|\\blogin\\b|\\bsign[- ]?up\\b\" \u2192 \"auth\""
+        }
+      ],
+      "doc_mirror": "C:\\CFH\\docs\\frontend\\src\\components\\needsHome\\CommunityDashboard.md"
+    },
+    {
+      "src": "C:\\CFH\\frontend\\src\\components\\needsHome\\CommunityHub.js",
+      "suggested_moves": [
+        {
+          "dest": "C:\\CFH\\frontend\\src\\components\\common\\CommunityHub.js",
+          "confidence": 0.3,
+          "reason": "Default to common (no strong signals)."
+        }
+      ],
+      "doc_mirror": "C:\\CFH\\docs\\frontend\\src\\components\\needsHome\\CommunityHub.md"
+    },
+    {
+      "src": "C:\\CFH\\frontend\\src\\components\\needsHome\\CommunityHubEnhanced.js",
+      "suggested_moves": [
+        {
+          "dest": "C:\\CFH\\frontend\\src\\components\\common\\CommunityHubEnhanced.js",
+          "confidence": 0.3,
+          "reason": "Default to common (no strong signals)."
+        }
+      ],
+      "doc_mirror": "C:\\CFH\\docs\\frontend\\src\\components\\needsHome\\CommunityHubEnhanced.md"
+    },
+    {
+      "src": "C:\\CFH\\frontend\\src\\components\\needsHome\\CommunityModeratorDashboard.js",
+      "suggested_moves": [
+        {
+          "dest": "C:\\CFH\\frontend\\src\\components\\common\\CommunityModeratorDashboard.js",
+          "confidence": 0.3,
+          "reason": "Default to common (no strong signals)."
+        }
+      ],
+      "doc_mirror": "C:\\CFH\\docs\\frontend\\src\\components\\needsHome\\CommunityModeratorDashboard.md"
+    },
+    {
+      "src": "C:\\CFH\\frontend\\src\\components\\needsHome\\ComplianceReviewerDashboard.js",
+      "suggested_moves": [
+        {
+          "dest": "C:\\CFH\\frontend\\src\\components\\common\\ComplianceReviewerDashboard.js",
+          "confidence": 0.3,
+          "reason": "Default to common (no strong signals)."
+        }
+      ],
+      "doc_mirror": "C:\\CFH\\docs\\frontend\\src\\components\\needsHome\\ComplianceReviewerDashboard.md"
+    },
+    {
+      "src": "C:\\CFH\\frontend\\src\\components\\needsHome\\CrossBorderFinancing.js",
+      "suggested_moves": [
+        {
+          "dest": "C:\\CFH\\frontend\\src\\components\\common\\CrossBorderFinancing.js",
+          "confidence": 0.3,
+          "reason": "Default to common (no strong signals)."
+        }
+      ],
+      "doc_mirror": "C:\\CFH\\docs\\frontend\\src\\components\\needsHome\\CrossBorderFinancing.md"
+    },
+    {
+      "src": "C:\\CFH\\frontend\\src\\components\\needsHome\\DynamicPricing.js",
+      "suggested_moves": [
+        {
+          "dest": "C:\\CFH\\frontend\\src\\components\\common\\DynamicPricing.js",
+          "confidence": 0.3,
+          "reason": "Default to common (no strong signals)."
+        }
+      ],
+      "doc_mirror": "C:\\CFH\\docs\\frontend\\src\\components\\needsHome\\DynamicPricing.md"
+    },
+    {
+      "src": "C:\\CFH\\frontend\\src\\components\\needsHome\\FinancingCalculator.js",
+      "suggested_moves": [
+        {
+          "dest": "C:\\CFH\\frontend\\src\\components\\finance\\FinancingCalculator.js",
+          "confidence": 0.7,
+          "reason": "Matched keyword rule \"\\bfinance\\b|\\bpayment\\b|\\binvoice\\b\" \u2192 \"finance\""
+        }
+      ],
+      "doc_mirror": "C:\\CFH\\docs\\frontend\\src\\components\\needsHome\\FinancingCalculator.md"
+    },
+    {
+      "src": "C:\\CFH\\frontend\\src\\components\\needsHome\\FraudDetection.js",
+      "suggested_moves": [
+        {
+          "dest": "C:\\CFH\\frontend\\src\\components\\common\\FraudDetection.js",
+          "confidence": 0.3,
+          "reason": "Default to common (no strong signals)."
+        }
+      ],
+      "doc_mirror": "C:\\CFH\\docs\\frontend\\src\\components\\needsHome\\FraudDetection.md"
+    },
+    {
+      "src": "C:\\CFH\\frontend\\src\\components\\needsHome\\integrationReportValidation.js",
+      "suggested_moves": [
+        {
+          "dest": "C:\\CFH\\frontend\\src\\components\\marketplace\\integrationReportValidation.js",
+          "confidence": 0.7,
+          "reason": "Matched keyword rule \"\\bmarketplace\\b|\\bsearch\\b|\\bresults?\\b\" \u2192 \"marketplace\""
+        }
+      ],
+      "doc_mirror": "C:\\CFH\\docs\\frontend\\src\\components\\needsHome\\integrationReportValidation.md"
+    },
+    {
+      "src": "C:\\CFH\\frontend\\src\\components\\needsHome\\Leaderboard.js",
+      "suggested_moves": [
+        {
+          "dest": "C:\\CFH\\frontend\\src\\components\\common\\Leaderboard.js",
+          "confidence": 0.3,
+          "reason": "Default to common (no strong signals)."
+        }
+      ],
+      "doc_mirror": "C:\\CFH\\docs\\frontend\\src\\components\\needsHome\\Leaderboard.md"
+    },
+    {
+      "src": "C:\\CFH\\frontend\\src\\components\\needsHome\\LeaveReview.js",
+      "suggested_moves": [
+        {
+          "dest": "C:\\CFH\\frontend\\src\\components\\chat\\LeaveReview.js",
+          "confidence": 0.7,
+          "reason": "Matched keyword rule \"\\bchat\\b|\\bmessage\\b|\\bthread\\b\" \u2192 \"chat\""
+        }
+      ],
+      "doc_mirror": "C:\\CFH\\docs\\frontend\\src\\components\\needsHome\\LeaveReview.md"
+    },
+    {
+      "src": "C:\\CFH\\frontend\\src\\components\\needsHome\\LoadingSpinner.js",
+      "suggested_moves": [
+        {
+          "dest": "C:\\CFH\\frontend\\src\\components\\common\\LoadingSpinner.js",
+          "confidence": 0.3,
+          "reason": "Default to common (no strong signals)."
+        }
+      ],
+      "doc_mirror": "C:\\CFH\\docs\\frontend\\src\\components\\needsHome\\LoadingSpinner.md"
+    },
+    {
+      "src": "C:\\CFH\\frontend\\src\\components\\needsHome\\LoanComparison.js",
+      "suggested_moves": [
+        {
+          "dest": "C:\\CFH\\frontend\\src\\components\\lender\\LoanComparison.js",
+          "confidence": 0.7,
+          "reason": "Matched keyword rule \"\\blender\\b|\\bloan\\b|\\bapr\\b|\\bcredit\\b\" \u2192 \"lender\""
+        }
+      ],
+      "doc_mirror": "C:\\CFH\\docs\\frontend\\src\\components\\needsHome\\LoanComparison.md"
+    },
+    {
+      "src": "C:\\CFH\\frontend\\src\\components\\needsHome\\LoyaltyQuests.js",
+      "suggested_moves": [
+        {
+          "dest": "C:\\CFH\\frontend\\src\\components\\common\\LoyaltyQuests.js",
+          "confidence": 0.3,
+          "reason": "Default to common (no strong signals)."
+        }
+      ],
+      "doc_mirror": "C:\\CFH\\docs\\frontend\\src\\components\\needsHome\\LoyaltyQuests.md"
+    },
+    {
+      "src": "C:\\CFH\\frontend\\src\\components\\needsHome\\MarketplaceInsights.js",
+      "suggested_moves": [
+        {
+          "dest": "C:\\CFH\\frontend\\src\\components\\marketplace\\MarketplaceInsights.js",
+          "confidence": 0.7,
+          "reason": "Matched keyword rule \"\\bmarketplace\\b|\\bsearch\\b|\\bresults?\\b\" \u2192 \"marketplace\""
+        }
+      ],
+      "doc_mirror": "C:\\CFH\\docs\\frontend\\src\\components\\needsHome\\MarketplaceInsights.md"
+    },
+    {
+      "src": "C:\\CFH\\frontend\\src\\components\\needsHome\\Messaging.js",
+      "suggested_moves": [
+        {
+          "dest": "C:\\CFH\\frontend\\src\\components\\chat\\Messaging.js",
+          "confidence": 0.7,
+          "reason": "Matched keyword rule \"\\bchat\\b|\\bmessage\\b|\\bthread\\b\" \u2192 \"chat\""
+        }
+      ],
+      "doc_mirror": "C:\\CFH\\docs\\frontend\\src\\components\\needsHome\\Messaging.md"
+    },
+    {
+      "src": "C:\\CFH\\frontend\\src\\components\\needsHome\\Navbar.js",
+      "suggested_moves": [
+        {
+          "dest": "C:\\CFH\\frontend\\src\\components\\buyer\\Navbar.js",
+          "confidence": 0.7,
+          "reason": "Matched keyword rule \"\\bbuyer\\b|\\bcheckout\\b|\\bbid\\b\" \u2192 \"buyer\""
+        }
+      ],
+      "doc_mirror": "C:\\CFH\\docs\\frontend\\src\\components\\needsHome\\Navbar.md"
+    },
+    {
+      "src": "C:\\CFH\\frontend\\src\\components\\needsHome\\NotificationCenter.js",
+      "suggested_moves": [
+        {
+          "dest": "C:\\CFH\\frontend\\src\\components\\chat\\NotificationCenter.js",
+          "confidence": 0.7,
+          "reason": "Matched keyword rule \"\\bchat\\b|\\bmessage\\b|\\bthread\\b\" \u2192 \"chat\""
+        }
+      ],
+      "doc_mirror": "C:\\CFH\\docs\\frontend\\src\\components\\needsHome\\NotificationCenter.md"
+    },
+    {
+      "src": "C:\\CFH\\frontend\\src\\components\\needsHome\\PaymentForm.js",
+      "suggested_moves": [
+        {
+          "dest": "C:\\CFH\\frontend\\src\\components\\chat\\PaymentForm.js",
+          "confidence": 0.7,
+          "reason": "Matched keyword rule \"\\bchat\\b|\\bmessage\\b|\\bthread\\b\" \u2192 \"chat\""
+        }
+      ],
+      "doc_mirror": "C:\\CFH\\docs\\frontend\\src\\components\\needsHome\\PaymentForm.md"
+    }
+  ]
+}

--- a/reports/reviews_20251003_161205.json
+++ b/reports/reviews_20251003_161205.json
@@ -1,0 +1,337 @@
+{
+  "root": "C:\\CFH\\frontend\\src\\components\\needsHome",
+  "generated_at": 1759533125,
+  "count": 30,
+  "items": [
+    {
+      "src": "C:\\CFH\\frontend\\src\\components\\needsHome\\AutomationAgent.js",
+      "suggested_moves": [
+        {
+          "dest": "C:\\CFH\\frontend\\src\\components\\common\\AutomationAgent.js",
+          "confidence": 0.3,
+          "reason": "Default to common (no strong signals)."
+        }
+      ],
+      "doc_mirror": "C:\\CFH\\docs\\frontend\\src\\components\\needsHome\\AutomationAgent.md"
+    },
+    {
+      "src": "C:\\CFH\\frontend\\src\\components\\needsHome\\BadgeDisplay.js",
+      "suggested_moves": [
+        {
+          "dest": "C:\\CFH\\frontend\\src\\components\\common\\BadgeDisplay.js",
+          "confidence": 0.3,
+          "reason": "Default to common (no strong signals)."
+        }
+      ],
+      "doc_mirror": "C:\\CFH\\docs\\frontend\\src\\components\\needsHome\\BadgeDisplay.md"
+    },
+    {
+      "src": "C:\\CFH\\frontend\\src\\components\\needsHome\\Button.js",
+      "suggested_moves": [
+        {
+          "dest": "C:\\CFH\\frontend\\src\\components\\common\\Button.js",
+          "confidence": 0.3,
+          "reason": "Default to common (no strong signals)."
+        }
+      ],
+      "doc_mirror": "C:\\CFH\\docs\\frontend\\src\\components\\needsHome\\Button.md"
+    },
+    {
+      "src": "C:\\CFH\\frontend\\src\\components\\needsHome\\CommunityHub.js",
+      "suggested_moves": [
+        {
+          "dest": "C:\\CFH\\frontend\\src\\components\\common\\CommunityHub.js",
+          "confidence": 0.3,
+          "reason": "Default to common (no strong signals)."
+        }
+      ],
+      "doc_mirror": "C:\\CFH\\docs\\frontend\\src\\components\\needsHome\\CommunityHub.md"
+    },
+    {
+      "src": "C:\\CFH\\frontend\\src\\components\\needsHome\\CommunityHubEnhanced.js",
+      "suggested_moves": [
+        {
+          "dest": "C:\\CFH\\frontend\\src\\components\\common\\CommunityHubEnhanced.js",
+          "confidence": 0.3,
+          "reason": "Default to common (no strong signals)."
+        }
+      ],
+      "doc_mirror": "C:\\CFH\\docs\\frontend\\src\\components\\needsHome\\CommunityHubEnhanced.md"
+    },
+    {
+      "src": "C:\\CFH\\frontend\\src\\components\\needsHome\\CommunityModeratorDashboard.js",
+      "suggested_moves": [
+        {
+          "dest": "C:\\CFH\\frontend\\src\\components\\common\\CommunityModeratorDashboard.js",
+          "confidence": 0.3,
+          "reason": "Default to common (no strong signals)."
+        }
+      ],
+      "doc_mirror": "C:\\CFH\\docs\\frontend\\src\\components\\needsHome\\CommunityModeratorDashboard.md"
+    },
+    {
+      "src": "C:\\CFH\\frontend\\src\\components\\needsHome\\ComplianceReviewerDashboard.js",
+      "suggested_moves": [
+        {
+          "dest": "C:\\CFH\\frontend\\src\\components\\common\\ComplianceReviewerDashboard.js",
+          "confidence": 0.3,
+          "reason": "Default to common (no strong signals)."
+        }
+      ],
+      "doc_mirror": "C:\\CFH\\docs\\frontend\\src\\components\\needsHome\\ComplianceReviewerDashboard.md"
+    },
+    {
+      "src": "C:\\CFH\\frontend\\src\\components\\needsHome\\CrossBorderFinancing.js",
+      "suggested_moves": [
+        {
+          "dest": "C:\\CFH\\frontend\\src\\components\\common\\CrossBorderFinancing.js",
+          "confidence": 0.3,
+          "reason": "Default to common (no strong signals)."
+        }
+      ],
+      "doc_mirror": "C:\\CFH\\docs\\frontend\\src\\components\\needsHome\\CrossBorderFinancing.md"
+    },
+    {
+      "src": "C:\\CFH\\frontend\\src\\components\\needsHome\\DynamicPricing.js",
+      "suggested_moves": [
+        {
+          "dest": "C:\\CFH\\frontend\\src\\components\\common\\DynamicPricing.js",
+          "confidence": 0.3,
+          "reason": "Default to common (no strong signals)."
+        }
+      ],
+      "doc_mirror": "C:\\CFH\\docs\\frontend\\src\\components\\needsHome\\DynamicPricing.md"
+    },
+    {
+      "src": "C:\\CFH\\frontend\\src\\components\\needsHome\\FraudDetection.js",
+      "suggested_moves": [
+        {
+          "dest": "C:\\CFH\\frontend\\src\\components\\common\\FraudDetection.js",
+          "confidence": 0.3,
+          "reason": "Default to common (no strong signals)."
+        }
+      ],
+      "doc_mirror": "C:\\CFH\\docs\\frontend\\src\\components\\needsHome\\FraudDetection.md"
+    },
+    {
+      "src": "C:\\CFH\\frontend\\src\\components\\needsHome\\Leaderboard.js",
+      "suggested_moves": [
+        {
+          "dest": "C:\\CFH\\frontend\\src\\components\\common\\Leaderboard.js",
+          "confidence": 0.3,
+          "reason": "Default to common (no strong signals)."
+        }
+      ],
+      "doc_mirror": "C:\\CFH\\docs\\frontend\\src\\components\\needsHome\\Leaderboard.md"
+    },
+    {
+      "src": "C:\\CFH\\frontend\\src\\components\\needsHome\\LoadingSpinner.js",
+      "suggested_moves": [
+        {
+          "dest": "C:\\CFH\\frontend\\src\\components\\common\\LoadingSpinner.js",
+          "confidence": 0.3,
+          "reason": "Default to common (no strong signals)."
+        }
+      ],
+      "doc_mirror": "C:\\CFH\\docs\\frontend\\src\\components\\needsHome\\LoadingSpinner.md"
+    },
+    {
+      "src": "C:\\CFH\\frontend\\src\\components\\needsHome\\LoyaltyQuests.js",
+      "suggested_moves": [
+        {
+          "dest": "C:\\CFH\\frontend\\src\\components\\common\\LoyaltyQuests.js",
+          "confidence": 0.3,
+          "reason": "Default to common (no strong signals)."
+        }
+      ],
+      "doc_mirror": "C:\\CFH\\docs\\frontend\\src\\components\\needsHome\\LoyaltyQuests.md"
+    },
+    {
+      "src": "C:\\CFH\\frontend\\src\\components\\needsHome\\ProtectedRoute.js",
+      "suggested_moves": [
+        {
+          "dest": "C:\\CFH\\frontend\\src\\components\\auth\\ProtectedRoute.js",
+          "confidence": 0.7,
+          "reason": "Matched keyword rule \"\\buser\\b|\\bauth\\b|\\blogin\\b|\\bsign[- ]?up\\b\" \u2192 \"auth\""
+        }
+      ],
+      "doc_mirror": "C:\\CFH\\docs\\frontend\\src\\components\\needsHome\\ProtectedRoute.md"
+    },
+    {
+      "src": "C:\\CFH\\frontend\\src\\components\\needsHome\\ReferralAnalytics.js",
+      "suggested_moves": [
+        {
+          "dest": "C:\\CFH\\frontend\\src\\components\\common\\ReferralAnalytics.js",
+          "confidence": 0.3,
+          "reason": "Default to common (no strong signals)."
+        }
+      ],
+      "doc_mirror": "C:\\CFH\\docs\\frontend\\src\\components\\needsHome\\ReferralAnalytics.md"
+    },
+    {
+      "src": "C:\\CFH\\frontend\\src\\components\\needsHome\\Register.js",
+      "suggested_moves": [
+        {
+          "dest": "C:\\CFH\\frontend\\src\\components\\buyer\\Register.js",
+          "confidence": 0.7,
+          "reason": "Matched keyword rule \"\\bbuyer\\b|\\bcheckout\\b|\\bbid\\b\" \u2192 \"buyer\""
+        }
+      ],
+      "doc_mirror": "C:\\CFH\\docs\\frontend\\src\\components\\needsHome\\Register.md"
+    },
+    {
+      "src": "C:\\CFH\\frontend\\src\\components\\needsHome\\RegisterForm.js",
+      "suggested_moves": [
+        {
+          "dest": "C:\\CFH\\frontend\\src\\components\\chat\\RegisterForm.js",
+          "confidence": 0.7,
+          "reason": "Matched keyword rule \"\\bchat\\b|\\bmessage\\b|\\bthread\\b\" \u2192 \"chat\""
+        }
+      ],
+      "doc_mirror": "C:\\CFH\\docs\\frontend\\src\\components\\needsHome\\RegisterForm.md"
+    },
+    {
+      "src": "C:\\CFH\\frontend\\src\\components\\needsHome\\ReputationBadgeTier.js",
+      "suggested_moves": [
+        {
+          "dest": "C:\\CFH\\frontend\\src\\components\\common\\ReputationBadgeTier.js",
+          "confidence": 0.3,
+          "reason": "Default to common (no strong signals)."
+        }
+      ],
+      "doc_mirror": "C:\\CFH\\docs\\frontend\\src\\components\\needsHome\\ReputationBadgeTier.md"
+    },
+    {
+      "src": "C:\\CFH\\frontend\\src\\components\\needsHome\\RoleActivityCharts.js",
+      "suggested_moves": [
+        {
+          "dest": "C:\\CFH\\frontend\\src\\components\\lender\\RoleActivityCharts.js",
+          "confidence": 0.7,
+          "reason": "Matched keyword rule \"\\blender\\b|\\bloan\\b|\\bapr\\b|\\bcredit\\b\" \u2192 \"lender\""
+        }
+      ],
+      "doc_mirror": "C:\\CFH\\docs\\frontend\\src\\components\\needsHome\\RoleActivityCharts.md"
+    },
+    {
+      "src": "C:\\CFH\\frontend\\src\\components\\needsHome\\RoleSwitchWrapper.js",
+      "suggested_moves": [
+        {
+          "dest": "C:\\CFH\\frontend\\src\\components\\auth\\RoleSwitchWrapper.js",
+          "confidence": 0.7,
+          "reason": "Matched keyword rule \"\\buser\\b|\\bauth\\b|\\blogin\\b|\\bsign[- ]?up\\b\" \u2192 \"auth\""
+        }
+      ],
+      "doc_mirror": "C:\\CFH\\docs\\frontend\\src\\components\\needsHome\\RoleSwitchWrapper.md"
+    },
+    {
+      "src": "C:\\CFH\\frontend\\src\\components\\needsHome\\SellerCreateListing.js",
+      "suggested_moves": [
+        {
+          "dest": "C:\\CFH\\frontend\\src\\components\\seller\\SellerCreateListing.js",
+          "confidence": 0.7,
+          "reason": "Matched keyword rule \"\\bseller\\b|\\blisting\\b|\\binventory\\b\" \u2192 \"seller\""
+        }
+      ],
+      "doc_mirror": "C:\\CFH\\docs\\frontend\\src\\components\\needsHome\\SellerCreateListing.md"
+    },
+    {
+      "src": "C:\\CFH\\frontend\\src\\components\\needsHome\\SellerDashboard.js",
+      "suggested_moves": [
+        {
+          "dest": "C:\\CFH\\frontend\\src\\components\\seller\\SellerDashboard.js",
+          "confidence": 0.7,
+          "reason": "Matched keyword rule \"\\bseller\\b|\\blisting\\b|\\binventory\\b\" \u2192 \"seller\""
+        }
+      ],
+      "doc_mirror": "C:\\CFH\\docs\\frontend\\src\\components\\needsHome\\SellerDashboard.md"
+    },
+    {
+      "src": "C:\\CFH\\frontend\\src\\components\\needsHome\\SmartRecommendations.js",
+      "suggested_moves": [
+        {
+          "dest": "C:\\CFH\\frontend\\src\\components\\buyer\\SmartRecommendations.js",
+          "confidence": 0.7,
+          "reason": "Matched keyword rule \"\\bbuyer\\b|\\bcheckout\\b|\\bbid\\b\" \u2192 \"buyer\""
+        }
+      ],
+      "doc_mirror": "C:\\CFH\\docs\\frontend\\src\\components\\needsHome\\SmartRecommendations.md"
+    },
+    {
+      "src": "C:\\CFH\\frontend\\src\\components\\needsHome\\SupportCenter.js",
+      "suggested_moves": [
+        {
+          "dest": "C:\\CFH\\frontend\\src\\components\\common\\SupportCenter.js",
+          "confidence": 0.3,
+          "reason": "Default to common (no strong signals)."
+        }
+      ],
+      "doc_mirror": "C:\\CFH\\docs\\frontend\\src\\components\\needsHome\\SupportCenter.md"
+    },
+    {
+      "src": "C:\\CFH\\frontend\\src\\components\\needsHome\\TradeInForm.js",
+      "suggested_moves": [
+        {
+          "dest": "C:\\CFH\\frontend\\src\\components\\chat\\TradeInForm.js",
+          "confidence": 0.7,
+          "reason": "Matched keyword rule \"\\bchat\\b|\\bmessage\\b|\\bthread\\b\" \u2192 \"chat\""
+        }
+      ],
+      "doc_mirror": "C:\\CFH\\docs\\frontend\\src\\components\\needsHome\\TradeInForm.md"
+    },
+    {
+      "src": "C:\\CFH\\frontend\\src\\components\\needsHome\\useAuth.js",
+      "suggested_moves": [
+        {
+          "dest": "C:\\CFH\\frontend\\src\\components\\auth\\useAuth.js",
+          "confidence": 0.7,
+          "reason": "Matched keyword rule \"\\buser\\b|\\bauth\\b|\\blogin\\b|\\bsign[- ]?up\\b\" \u2192 \"auth\""
+        }
+      ],
+      "doc_mirror": "C:\\CFH\\docs\\frontend\\src\\components\\needsHome\\useAuth.md"
+    },
+    {
+      "src": "C:\\CFH\\frontend\\src\\components\\needsHome\\UserProfile.js",
+      "suggested_moves": [
+        {
+          "dest": "C:\\CFH\\frontend\\src\\components\\chat\\UserProfile.js",
+          "confidence": 0.7,
+          "reason": "Matched keyword rule \"\\bchat\\b|\\bmessage\\b|\\bthread\\b\" \u2192 \"chat\""
+        }
+      ],
+      "doc_mirror": "C:\\CFH\\docs\\frontend\\src\\components\\needsHome\\UserProfile.md"
+    },
+    {
+      "src": "C:\\CFH\\frontend\\src\\components\\needsHome\\UserReviewList.js",
+      "suggested_moves": [
+        {
+          "dest": "C:\\CFH\\frontend\\src\\components\\auth\\UserReviewList.js",
+          "confidence": 0.7,
+          "reason": "Matched keyword rule \"\\buser\\b|\\bauth\\b|\\blogin\\b|\\bsign[- ]?up\\b\" \u2192 \"auth\""
+        }
+      ],
+      "doc_mirror": "C:\\CFH\\docs\\frontend\\src\\components\\needsHome\\UserReviewList.md"
+    },
+    {
+      "src": "C:\\CFH\\frontend\\src\\components\\needsHome\\VoiceInteraction.js",
+      "suggested_moves": [
+        {
+          "dest": "C:\\CFH\\frontend\\src\\components\\common\\VoiceInteraction.js",
+          "confidence": 0.3,
+          "reason": "Default to common (no strong signals)."
+        }
+      ],
+      "doc_mirror": "C:\\CFH\\docs\\frontend\\src\\components\\needsHome\\VoiceInteraction.md"
+    },
+    {
+      "src": "C:\\CFH\\frontend\\src\\components\\needsHome\\VRViewer.js",
+      "suggested_moves": [
+        {
+          "dest": "C:\\CFH\\frontend\\src\\components\\common\\VRViewer.js",
+          "confidence": 0.3,
+          "reason": "Default to common (no strong signals)."
+        }
+      ],
+      "doc_mirror": "C:\\CFH\\docs\\frontend\\src\\components\\needsHome\\VRViewer.md"
+    }
+  ]
+}

--- a/reports/routing_audit_reviews_20251003_154759.csv
+++ b/reports/routing_audit_reviews_20251003_154759.csv
@@ -1,0 +1,26 @@
+src,dest,confidence,reason,applied
+C:\CFH\frontend\src\components\needsHome\ARExperience.js,C:\CFH\frontend\src\components\seller\ARExperience.js,0.7,"Matched keyword rule ""\bseller\b|\blisting\b|\binventory\b"" → ""seller""",False
+C:\CFH\frontend\src\components\needsHome\AutomationAgent.js,C:\CFH\frontend\src\components\common\AutomationAgent.js,0.3,Default to common (no strong signals).,False
+C:\CFH\frontend\src\components\needsHome\BadgeDisplay.js,C:\CFH\frontend\src\components\common\BadgeDisplay.js,0.3,Default to common (no strong signals).,False
+C:\CFH\frontend\src\components\needsHome\BulkUpload.js,C:\CFH\frontend\src\components\chat\BulkUpload.js,0.7,"Matched keyword rule ""\bchat\b|\bmessage\b|\bthread\b"" → ""chat""",False
+C:\CFH\frontend\src\components\needsHome\Button.js,C:\CFH\frontend\src\components\common\Button.js,0.3,Default to common (no strong signals).,False
+C:\CFH\frontend\src\components\needsHome\CommunityDashboard.js,C:\CFH\frontend\src\components\auth\CommunityDashboard.js,0.7,"Matched keyword rule ""\buser\b|\bauth\b|\blogin\b|\bsign[- ]?up\b"" → ""auth""",False
+C:\CFH\frontend\src\components\needsHome\CommunityHub.js,C:\CFH\frontend\src\components\common\CommunityHub.js,0.3,Default to common (no strong signals).,False
+C:\CFH\frontend\src\components\needsHome\CommunityHubEnhanced.js,C:\CFH\frontend\src\components\common\CommunityHubEnhanced.js,0.3,Default to common (no strong signals).,False
+C:\CFH\frontend\src\components\needsHome\CommunityModeratorDashboard.js,C:\CFH\frontend\src\components\common\CommunityModeratorDashboard.js,0.3,Default to common (no strong signals).,False
+C:\CFH\frontend\src\components\needsHome\ComplianceReviewerDashboard.js,C:\CFH\frontend\src\components\common\ComplianceReviewerDashboard.js,0.3,Default to common (no strong signals).,False
+C:\CFH\frontend\src\components\needsHome\CrossBorderFinancing.js,C:\CFH\frontend\src\components\common\CrossBorderFinancing.js,0.3,Default to common (no strong signals).,False
+C:\CFH\frontend\src\components\needsHome\DynamicPricing.js,C:\CFH\frontend\src\components\common\DynamicPricing.js,0.3,Default to common (no strong signals).,False
+C:\CFH\frontend\src\components\needsHome\FinancingCalculator.js,C:\CFH\frontend\src\components\finance\FinancingCalculator.js,0.7,"Matched keyword rule ""\bfinance\b|\bpayment\b|\binvoice\b"" → ""finance""",False
+C:\CFH\frontend\src\components\needsHome\FraudDetection.js,C:\CFH\frontend\src\components\common\FraudDetection.js,0.3,Default to common (no strong signals).,False
+C:\CFH\frontend\src\components\needsHome\integrationReportValidation.js,C:\CFH\frontend\src\components\marketplace\integrationReportValidation.js,0.7,"Matched keyword rule ""\bmarketplace\b|\bsearch\b|\bresults?\b"" → ""marketplace""",False
+C:\CFH\frontend\src\components\needsHome\Leaderboard.js,C:\CFH\frontend\src\components\common\Leaderboard.js,0.3,Default to common (no strong signals).,False
+C:\CFH\frontend\src\components\needsHome\LeaveReview.js,C:\CFH\frontend\src\components\chat\LeaveReview.js,0.7,"Matched keyword rule ""\bchat\b|\bmessage\b|\bthread\b"" → ""chat""",False
+C:\CFH\frontend\src\components\needsHome\LoadingSpinner.js,C:\CFH\frontend\src\components\common\LoadingSpinner.js,0.3,Default to common (no strong signals).,False
+C:\CFH\frontend\src\components\needsHome\LoanComparison.js,C:\CFH\frontend\src\components\lender\LoanComparison.js,0.7,"Matched keyword rule ""\blender\b|\bloan\b|\bapr\b|\bcredit\b"" → ""lender""",False
+C:\CFH\frontend\src\components\needsHome\LoyaltyQuests.js,C:\CFH\frontend\src\components\common\LoyaltyQuests.js,0.3,Default to common (no strong signals).,False
+C:\CFH\frontend\src\components\needsHome\MarketplaceInsights.js,C:\CFH\frontend\src\components\marketplace\MarketplaceInsights.js,0.7,"Matched keyword rule ""\bmarketplace\b|\bsearch\b|\bresults?\b"" → ""marketplace""",False
+C:\CFH\frontend\src\components\needsHome\Messaging.js,C:\CFH\frontend\src\components\chat\Messaging.js,0.7,"Matched keyword rule ""\bchat\b|\bmessage\b|\bthread\b"" → ""chat""",False
+C:\CFH\frontend\src\components\needsHome\Navbar.js,C:\CFH\frontend\src\components\buyer\Navbar.js,0.7,"Matched keyword rule ""\bbuyer\b|\bcheckout\b|\bbid\b"" → ""buyer""",False
+C:\CFH\frontend\src\components\needsHome\NotificationCenter.js,C:\CFH\frontend\src\components\chat\NotificationCenter.js,0.7,"Matched keyword rule ""\bchat\b|\bmessage\b|\bthread\b"" → ""chat""",False
+C:\CFH\frontend\src\components\needsHome\PaymentForm.js,C:\CFH\frontend\src\components\chat\PaymentForm.js,0.7,"Matched keyword rule ""\bchat\b|\bmessage\b|\bthread\b"" → ""chat""",False

--- a/reports/routing_audit_reviews_20251003_154759.csv
+++ b/reports/routing_audit_reviews_20251003_154759.csv
@@ -1,26 +1,26 @@
 src,dest,confidence,reason,applied
-C:\CFH\frontend\src\components\needsHome\ARExperience.js,C:\CFH\frontend\src\components\seller\ARExperience.js,0.7,"Matched keyword rule ""\bseller\b|\blisting\b|\binventory\b"" → ""seller""",False
+C:\CFH\frontend\src\components\needsHome\ARExperience.js,C:\CFH\frontend\src\components\seller\ARExperience.js,0.7,"Matched keyword rule ""\bseller\b|\blisting\b|\binventory\b"" → ""seller""",True
 C:\CFH\frontend\src\components\needsHome\AutomationAgent.js,C:\CFH\frontend\src\components\common\AutomationAgent.js,0.3,Default to common (no strong signals).,False
 C:\CFH\frontend\src\components\needsHome\BadgeDisplay.js,C:\CFH\frontend\src\components\common\BadgeDisplay.js,0.3,Default to common (no strong signals).,False
-C:\CFH\frontend\src\components\needsHome\BulkUpload.js,C:\CFH\frontend\src\components\chat\BulkUpload.js,0.7,"Matched keyword rule ""\bchat\b|\bmessage\b|\bthread\b"" → ""chat""",False
+C:\CFH\frontend\src\components\needsHome\BulkUpload.js,C:\CFH\frontend\src\components\chat\BulkUpload.js,0.7,"Matched keyword rule ""\bchat\b|\bmessage\b|\bthread\b"" → ""chat""",True
 C:\CFH\frontend\src\components\needsHome\Button.js,C:\CFH\frontend\src\components\common\Button.js,0.3,Default to common (no strong signals).,False
-C:\CFH\frontend\src\components\needsHome\CommunityDashboard.js,C:\CFH\frontend\src\components\auth\CommunityDashboard.js,0.7,"Matched keyword rule ""\buser\b|\bauth\b|\blogin\b|\bsign[- ]?up\b"" → ""auth""",False
+C:\CFH\frontend\src\components\needsHome\CommunityDashboard.js,C:\CFH\frontend\src\components\auth\CommunityDashboard.js,0.7,"Matched keyword rule ""\buser\b|\bauth\b|\blogin\b|\bsign[- ]?up\b"" → ""auth""",True
 C:\CFH\frontend\src\components\needsHome\CommunityHub.js,C:\CFH\frontend\src\components\common\CommunityHub.js,0.3,Default to common (no strong signals).,False
 C:\CFH\frontend\src\components\needsHome\CommunityHubEnhanced.js,C:\CFH\frontend\src\components\common\CommunityHubEnhanced.js,0.3,Default to common (no strong signals).,False
 C:\CFH\frontend\src\components\needsHome\CommunityModeratorDashboard.js,C:\CFH\frontend\src\components\common\CommunityModeratorDashboard.js,0.3,Default to common (no strong signals).,False
 C:\CFH\frontend\src\components\needsHome\ComplianceReviewerDashboard.js,C:\CFH\frontend\src\components\common\ComplianceReviewerDashboard.js,0.3,Default to common (no strong signals).,False
 C:\CFH\frontend\src\components\needsHome\CrossBorderFinancing.js,C:\CFH\frontend\src\components\common\CrossBorderFinancing.js,0.3,Default to common (no strong signals).,False
 C:\CFH\frontend\src\components\needsHome\DynamicPricing.js,C:\CFH\frontend\src\components\common\DynamicPricing.js,0.3,Default to common (no strong signals).,False
-C:\CFH\frontend\src\components\needsHome\FinancingCalculator.js,C:\CFH\frontend\src\components\finance\FinancingCalculator.js,0.7,"Matched keyword rule ""\bfinance\b|\bpayment\b|\binvoice\b"" → ""finance""",False
+C:\CFH\frontend\src\components\needsHome\FinancingCalculator.js,C:\CFH\frontend\src\components\finance\FinancingCalculator.js,0.7,"Matched keyword rule ""\bfinance\b|\bpayment\b|\binvoice\b"" → ""finance""",True
 C:\CFH\frontend\src\components\needsHome\FraudDetection.js,C:\CFH\frontend\src\components\common\FraudDetection.js,0.3,Default to common (no strong signals).,False
-C:\CFH\frontend\src\components\needsHome\integrationReportValidation.js,C:\CFH\frontend\src\components\marketplace\integrationReportValidation.js,0.7,"Matched keyword rule ""\bmarketplace\b|\bsearch\b|\bresults?\b"" → ""marketplace""",False
+C:\CFH\frontend\src\components\needsHome\integrationReportValidation.js,C:\CFH\frontend\src\components\marketplace\integrationReportValidation.js,0.7,"Matched keyword rule ""\bmarketplace\b|\bsearch\b|\bresults?\b"" → ""marketplace""",True
 C:\CFH\frontend\src\components\needsHome\Leaderboard.js,C:\CFH\frontend\src\components\common\Leaderboard.js,0.3,Default to common (no strong signals).,False
-C:\CFH\frontend\src\components\needsHome\LeaveReview.js,C:\CFH\frontend\src\components\chat\LeaveReview.js,0.7,"Matched keyword rule ""\bchat\b|\bmessage\b|\bthread\b"" → ""chat""",False
+C:\CFH\frontend\src\components\needsHome\LeaveReview.js,C:\CFH\frontend\src\components\chat\LeaveReview.js,0.7,"Matched keyword rule ""\bchat\b|\bmessage\b|\bthread\b"" → ""chat""",True
 C:\CFH\frontend\src\components\needsHome\LoadingSpinner.js,C:\CFH\frontend\src\components\common\LoadingSpinner.js,0.3,Default to common (no strong signals).,False
-C:\CFH\frontend\src\components\needsHome\LoanComparison.js,C:\CFH\frontend\src\components\lender\LoanComparison.js,0.7,"Matched keyword rule ""\blender\b|\bloan\b|\bapr\b|\bcredit\b"" → ""lender""",False
+C:\CFH\frontend\src\components\needsHome\LoanComparison.js,C:\CFH\frontend\src\components\lender\LoanComparison.js,0.7,"Matched keyword rule ""\blender\b|\bloan\b|\bapr\b|\bcredit\b"" → ""lender""",True
 C:\CFH\frontend\src\components\needsHome\LoyaltyQuests.js,C:\CFH\frontend\src\components\common\LoyaltyQuests.js,0.3,Default to common (no strong signals).,False
-C:\CFH\frontend\src\components\needsHome\MarketplaceInsights.js,C:\CFH\frontend\src\components\marketplace\MarketplaceInsights.js,0.7,"Matched keyword rule ""\bmarketplace\b|\bsearch\b|\bresults?\b"" → ""marketplace""",False
-C:\CFH\frontend\src\components\needsHome\Messaging.js,C:\CFH\frontend\src\components\chat\Messaging.js,0.7,"Matched keyword rule ""\bchat\b|\bmessage\b|\bthread\b"" → ""chat""",False
-C:\CFH\frontend\src\components\needsHome\Navbar.js,C:\CFH\frontend\src\components\buyer\Navbar.js,0.7,"Matched keyword rule ""\bbuyer\b|\bcheckout\b|\bbid\b"" → ""buyer""",False
-C:\CFH\frontend\src\components\needsHome\NotificationCenter.js,C:\CFH\frontend\src\components\chat\NotificationCenter.js,0.7,"Matched keyword rule ""\bchat\b|\bmessage\b|\bthread\b"" → ""chat""",False
-C:\CFH\frontend\src\components\needsHome\PaymentForm.js,C:\CFH\frontend\src\components\chat\PaymentForm.js,0.7,"Matched keyword rule ""\bchat\b|\bmessage\b|\bthread\b"" → ""chat""",False
+C:\CFH\frontend\src\components\needsHome\MarketplaceInsights.js,C:\CFH\frontend\src\components\marketplace\MarketplaceInsights.js,0.7,"Matched keyword rule ""\bmarketplace\b|\bsearch\b|\bresults?\b"" → ""marketplace""",True
+C:\CFH\frontend\src\components\needsHome\Messaging.js,C:\CFH\frontend\src\components\chat\Messaging.js,0.7,"Matched keyword rule ""\bchat\b|\bmessage\b|\bthread\b"" → ""chat""",True
+C:\CFH\frontend\src\components\needsHome\Navbar.js,C:\CFH\frontend\src\components\buyer\Navbar.js,0.7,"Matched keyword rule ""\bbuyer\b|\bcheckout\b|\bbid\b"" → ""buyer""",True
+C:\CFH\frontend\src\components\needsHome\NotificationCenter.js,C:\CFH\frontend\src\components\chat\NotificationCenter.js,0.7,"Matched keyword rule ""\bchat\b|\bmessage\b|\bthread\b"" → ""chat""",True
+C:\CFH\frontend\src\components\needsHome\PaymentForm.js,C:\CFH\frontend\src\components\chat\PaymentForm.js,0.7,"Matched keyword rule ""\bchat\b|\bmessage\b|\bthread\b"" → ""chat""",True

--- a/reports/routing_audit_reviews_20251003_161205.csv
+++ b/reports/routing_audit_reviews_20251003_161205.csv
@@ -1,0 +1,31 @@
+src,dest,confidence,reason,applied
+C:\CFH\frontend\src\components\needsHome\AutomationAgent.js,C:\CFH\frontend\src\components\common\AutomationAgent.js,0.3,Default to common (no strong signals).,False
+C:\CFH\frontend\src\components\needsHome\BadgeDisplay.js,C:\CFH\frontend\src\components\common\BadgeDisplay.js,0.3,Default to common (no strong signals).,False
+C:\CFH\frontend\src\components\needsHome\Button.js,C:\CFH\frontend\src\components\common\Button.js,0.3,Default to common (no strong signals).,False
+C:\CFH\frontend\src\components\needsHome\CommunityHub.js,C:\CFH\frontend\src\components\common\CommunityHub.js,0.3,Default to common (no strong signals).,False
+C:\CFH\frontend\src\components\needsHome\CommunityHubEnhanced.js,C:\CFH\frontend\src\components\common\CommunityHubEnhanced.js,0.3,Default to common (no strong signals).,False
+C:\CFH\frontend\src\components\needsHome\CommunityModeratorDashboard.js,C:\CFH\frontend\src\components\common\CommunityModeratorDashboard.js,0.3,Default to common (no strong signals).,False
+C:\CFH\frontend\src\components\needsHome\ComplianceReviewerDashboard.js,C:\CFH\frontend\src\components\common\ComplianceReviewerDashboard.js,0.3,Default to common (no strong signals).,False
+C:\CFH\frontend\src\components\needsHome\CrossBorderFinancing.js,C:\CFH\frontend\src\components\common\CrossBorderFinancing.js,0.3,Default to common (no strong signals).,False
+C:\CFH\frontend\src\components\needsHome\DynamicPricing.js,C:\CFH\frontend\src\components\common\DynamicPricing.js,0.3,Default to common (no strong signals).,False
+C:\CFH\frontend\src\components\needsHome\FraudDetection.js,C:\CFH\frontend\src\components\common\FraudDetection.js,0.3,Default to common (no strong signals).,False
+C:\CFH\frontend\src\components\needsHome\Leaderboard.js,C:\CFH\frontend\src\components\common\Leaderboard.js,0.3,Default to common (no strong signals).,False
+C:\CFH\frontend\src\components\needsHome\LoadingSpinner.js,C:\CFH\frontend\src\components\common\LoadingSpinner.js,0.3,Default to common (no strong signals).,False
+C:\CFH\frontend\src\components\needsHome\LoyaltyQuests.js,C:\CFH\frontend\src\components\common\LoyaltyQuests.js,0.3,Default to common (no strong signals).,False
+C:\CFH\frontend\src\components\needsHome\ProtectedRoute.js,C:\CFH\frontend\src\components\auth\ProtectedRoute.js,0.7,"Matched keyword rule ""\buser\b|\bauth\b|\blogin\b|\bsign[- ]?up\b"" → ""auth""",False
+C:\CFH\frontend\src\components\needsHome\ReferralAnalytics.js,C:\CFH\frontend\src\components\common\ReferralAnalytics.js,0.3,Default to common (no strong signals).,False
+C:\CFH\frontend\src\components\needsHome\Register.js,C:\CFH\frontend\src\components\buyer\Register.js,0.7,"Matched keyword rule ""\bbuyer\b|\bcheckout\b|\bbid\b"" → ""buyer""",False
+C:\CFH\frontend\src\components\needsHome\RegisterForm.js,C:\CFH\frontend\src\components\chat\RegisterForm.js,0.7,"Matched keyword rule ""\bchat\b|\bmessage\b|\bthread\b"" → ""chat""",False
+C:\CFH\frontend\src\components\needsHome\ReputationBadgeTier.js,C:\CFH\frontend\src\components\common\ReputationBadgeTier.js,0.3,Default to common (no strong signals).,False
+C:\CFH\frontend\src\components\needsHome\RoleActivityCharts.js,C:\CFH\frontend\src\components\lender\RoleActivityCharts.js,0.7,"Matched keyword rule ""\blender\b|\bloan\b|\bapr\b|\bcredit\b"" → ""lender""",False
+C:\CFH\frontend\src\components\needsHome\RoleSwitchWrapper.js,C:\CFH\frontend\src\components\auth\RoleSwitchWrapper.js,0.7,"Matched keyword rule ""\buser\b|\bauth\b|\blogin\b|\bsign[- ]?up\b"" → ""auth""",False
+C:\CFH\frontend\src\components\needsHome\SellerCreateListing.js,C:\CFH\frontend\src\components\seller\SellerCreateListing.js,0.7,"Matched keyword rule ""\bseller\b|\blisting\b|\binventory\b"" → ""seller""",False
+C:\CFH\frontend\src\components\needsHome\SellerDashboard.js,C:\CFH\frontend\src\components\seller\SellerDashboard.js,0.7,"Matched keyword rule ""\bseller\b|\blisting\b|\binventory\b"" → ""seller""",False
+C:\CFH\frontend\src\components\needsHome\SmartRecommendations.js,C:\CFH\frontend\src\components\buyer\SmartRecommendations.js,0.7,"Matched keyword rule ""\bbuyer\b|\bcheckout\b|\bbid\b"" → ""buyer""",False
+C:\CFH\frontend\src\components\needsHome\SupportCenter.js,C:\CFH\frontend\src\components\common\SupportCenter.js,0.3,Default to common (no strong signals).,False
+C:\CFH\frontend\src\components\needsHome\TradeInForm.js,C:\CFH\frontend\src\components\chat\TradeInForm.js,0.7,"Matched keyword rule ""\bchat\b|\bmessage\b|\bthread\b"" → ""chat""",False
+C:\CFH\frontend\src\components\needsHome\useAuth.js,C:\CFH\frontend\src\components\auth\useAuth.js,0.7,"Matched keyword rule ""\buser\b|\bauth\b|\blogin\b|\bsign[- ]?up\b"" → ""auth""",False
+C:\CFH\frontend\src\components\needsHome\UserProfile.js,C:\CFH\frontend\src\components\chat\UserProfile.js,0.7,"Matched keyword rule ""\bchat\b|\bmessage\b|\bthread\b"" → ""chat""",False
+C:\CFH\frontend\src\components\needsHome\UserReviewList.js,C:\CFH\frontend\src\components\auth\UserReviewList.js,0.7,"Matched keyword rule ""\buser\b|\bauth\b|\blogin\b|\bsign[- ]?up\b"" → ""auth""",False
+C:\CFH\frontend\src\components\needsHome\VoiceInteraction.js,C:\CFH\frontend\src\components\common\VoiceInteraction.js,0.3,Default to common (no strong signals).,False
+C:\CFH\frontend\src\components\needsHome\VRViewer.js,C:\CFH\frontend\src\components\common\VRViewer.js,0.3,Default to common (no strong signals).,False

--- a/run_convert_tree_dryruns.ps1
+++ b/run_convert_tree_dryruns.ps1
@@ -1,0 +1,32 @@
+# Auto-generated: call /convert/tree dry-runs per root
+param(
+  [string]$ApiHost = $env:HOST
+, [int]$ApiPort    = [int]($env:PORT)
+)
+
+if (-not $ApiHost) { $ApiHost = "127.0.0.1" }
+if (-not $ApiPort) { $ApiPort = 8121 }
+
+$base = "http://$ApiHost`:$ApiPort"
+Write-Host "Posting to $base/convert/tree" -ForegroundColor Cyan
+
+$roots = @(
+  "C:\Backup_Projects"
+  "C:\CFH\TruthSource"
+  "C:\CFH\backend"
+  "C:\CFH\docs"
+  "C:\CFH\frontend"
+  "M:\cfh"
+)
+
+foreach ($r in $roots) {
+  $payload = @{ root = $r; dry_run = $true } | ConvertTo-Json -Compress
+  try {
+    $resp = Invoke-RestMethod -Method POST -Uri "$base/convert/tree" -ContentType "application/json" -Body $payload
+    $ok = if ($resp.ok) { "OK" } else { "ERR" }
+    "{0} {1} (converted={2}, skipped={3})" -f $ok, $r, ($resp.converted | Measure-Object | % Count), ($resp.skipped | Measure-Object | % Count)
+  } catch {
+    "ERR {0}: $($_.Exception.Message)" -f $r
+  }
+}
+

--- a/uvicorn.out.log
+++ b/uvicorn.out.log
@@ -1,0 +1,4 @@
+INFO:     127.0.0.1:63095 - "GET /_health HTTP/1.1" 200 OK
+INFO:     127.0.0.1:63096 - "GET /_meta/routes HTTP/1.1" 200 OK
+INFO:     127.0.0.1:63097 - "GET /readyz HTTP/1.1" 200 OK
+INFO:     127.0.0.1:63100 - "POST /convert/tree HTTP/1.1" 200 OK


### PR DESCRIPTION
- **readyz: provider matrix (sdk+key); ensure Anthropic false without key**
- **readyz: de-dup providers_enabled; keep single canonical line**
- **ci: fix indentation for probes job**
- **routing: apply needsHome (≥0.70); 12 moves + 25 docs mirror**
- **routing: needsHome (≥0.85) follow-up; moves + docs mirror**
- **convert(tree): filter noise + inline tests; stable artifact path**
