### PR TITLE
Phase 3: Redis adapter (flag-gated) + async factory + shim update

### DIFF
--- a/reports/redis_adapter_notes.md
+++ b/reports/redis_adapter_notes.md
@@ -1,0 +1,7 @@
+# Escrow Queue — Redis Adapter
+- Set `CFH_REDIS_ESCROW=1` to enable Redis-backed queue.
+- Provide `REDIS_URL` (default: `redis://localhost:6379/0`).
+- Factory `getEscrowQueue()` is async; update callers accordingly.
+
+Install (dev only):
+  npm i -D redis

--- a/scripts/queue_stats.ts
+++ b/scripts/queue_stats.ts
@@ -1,11 +1,11 @@
 /**
  * Minimal shim: import queue & dump stats to console for wave scripts.
- * Later: replace with HTTP call to /redis/health once API endpoint exists.
+ * Now awaits the async factory. Later: replace with HTTP /redis/health.
  */
 import { getEscrowQueue } from "../src/_ai_out/redis_stubs/EscrowQueueService.tsx";
 
 async function main() {
-  const q = getEscrowQueue();
+  const q = await getEscrowQueue();
   const s = await q.stats();
   // CSV-ish line for easy grep/append by existing wave tooling
   // ts, module, queued, processing, acked, failed


### PR DESCRIPTION
- Adds async `getEscrowQueue()` that prefers Redis when CFH_REDIS_ESCROW=1 (lazy import)
- Keeps in-memory default otherwise
- Updates `scripts/queue_stats.ts` to `await getEscrowQueue()`
- Notes in `reports/redis_adapter_notes.md`